### PR TITLE
Consolidated our dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
-networkx>=2.1
-numpy>=1.8.1
-scikit-learn>=0.19.1
-scipy>=1.4.0
-seaborn>=0.9.0
-matplotlib>=3.0.0,<=3.3.0
-hyppo>=0.1.2
+-e .[dev]
 

--- a/setup.py
+++ b/setup.py
@@ -4,60 +4,36 @@
 import os
 import sys
 from setuptools import setup, find_packages
-from typing import Tuple
 
 
-def package_metadata() -> Tuple[str, str]:
-    sys.path.insert(0, os.path.join("graspy", "version"))  # TODO: #454 Change path in https://github.com/microsoft/graspologic/issues/454
-    from version import name, version
-    sys.path.pop(0)
+MINIMUM_PYTHON_VERSION = 3, 6  # Minimum of Python 3.6
 
-    version_path = os.path.join("graspy", "version", "version.txt")
-    with open(version_path, "w") as version_file:
-        _b = version_file.write(f"{version}")
-    return name, version
+if sys.version_info < MINIMUM_PYTHON_VERSION:
+    sys.exit("Python {}.{}+ is required.".format(*MINIMUM_PYTHON_VERSION))
 
+sys.path.insert(0, os.path.join("graspy", "version"))
+# TODO: #454 Change path in https://github.com/microsoft/graspologic/issues/454
+from version import version
+sys.path.pop(0)
 
-PACKAGE_NAME, VERSION = package_metadata()
+version_path = os.path.join("graspy", "version", "version.txt")
+with open(version_path, "w") as version_file:
+    _b = version_file.write(f"{version}")
 
-DESCRIPTION = "A set of python modules for graph statistics"
 with open("README.md", "r") as f:
     LONG_DESCRIPTION = f.read()
-AUTHOR = ("Eric Bridgeford, Jaewon Chung, Benjamin Pedigo, Bijan Varjavand",)
-AUTHOR_EMAIL = "j1c@jhu.edu"
-URL = "https://github.com/neurodata/graspy"
-MINIMUM_PYTHON_VERSION = 3, 6  # Minimum of Python 3.6
-REQUIRED_PACKAGES = [
-    "networkx>=2.1",
-    "numpy>=1.8.1",
-    "scikit-learn>=0.19.1",
-    "scipy>=1.4.0",
-    "seaborn>=0.9.0",
-    "matplotlib>=3.0.0",
-    "hyppo>=0.1.3",
-]
-
-
-def check_python_version():
-    """Exit when the Python version is too low."""
-    if sys.version_info < MINIMUM_PYTHON_VERSION:
-        sys.exit("Python {}.{}+ is required.".format(*MINIMUM_PYTHON_VERSION))
-
-
-check_python_version()
 
 setup(
-    name=PACKAGE_NAME,
-    version=VERSION,
-    description=DESCRIPTION,
+    name="graspy",
+    version=version,
+    description="A set of python modules for graph statistics",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
-    author=AUTHOR,
-    author_email=AUTHOR_EMAIL,
+    author="Eric Bridgeford, Jaewon Chung, Benjamin Pedigo, Bijan Varjavand",
+    author_email="j1c@jhu.edu",
     maintainer="Dwayne Pryce",
     maintainer_email="dwpryce@microsoft.com",
-    install_requires=REQUIRED_PACKAGES,
-    url=URL,
+    url="https://github.com/microsoft/graspologic",
     license="MIT",
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -70,5 +46,25 @@ setup(
     ],
     packages=find_packages(exclude=["tests", "tests.*", "tests/*"]),
     include_package_data=True,
-    package_data={'version': [os.path.join('graspy', 'version', 'version.txt')]},  # TODO: #454 Also needs changed by https://github.com/microsoft/graspologic/issues/454,
+    package_data={
+        "version": [os.path.join("graspy", "version", "version.txt")]
+    },  # TODO: #454 Also needs changed by https://github.com/microsoft/graspologic/issues/454
+    install_requires=[
+        "networkx>=2.1",
+        "numpy>=1.8.1",
+        "scikit-learn>=0.19.1",
+        "scipy>=1.4.0",
+        "seaborn>=0.9.0",
+        "matplotlib>=3.0.0",
+        "hyppo>=0.1.3",
+    ],
+    extras_require={
+        "dev": [
+            "black",
+            "mypy",
+            "pytest",
+            "pytest-cov",
+            "sphinx-rtd-theme"
+        ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,16 @@ setup(
     extras_require={
         "dev": [
             "black",
+            "ipykernel>=5.1.0",
+            "ipython>=7.4.0",
             "mypy",
+            "nbsphinx",
+            "numpydoc",
             "pytest",
             "pytest-cov",
-            "sphinx-rtd-theme"
+            "sphinx"
+            "sphinxcontrib-rawfiles",
+            "sphinx-rtd-theme",
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
             "numpydoc",
             "pytest",
             "pytest-cov",
-            "sphinx"
+            "sphinx",
             "sphinxcontrib-rawfiles",
             "sphinx-rtd-theme",
         ]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ sys.path.pop(0)
 
 version_path = os.path.join("graspy", "version", "version.txt")
 with open(version_path, "w") as version_file:
-    _b = version_file.write(f"{version}")
+    version_file.write(f"{version}")
 
 with open("README.md", "r") as f:
     LONG_DESCRIPTION = f.read()
@@ -55,7 +55,7 @@ setup(
         "scikit-learn>=0.19.1",
         "scipy>=1.4.0",
         "seaborn>=0.9.0",
-        "matplotlib>=3.0.0",
+        "matplotlib>=3.0.0,<=3.3.0",
         "hyppo>=0.1.3",
     ],
     extras_require={


### PR DESCRIPTION
Consolidated our requirements into a single file, setup.py.  Also updated it to include a new extra requires target that includes all of our build tools; black, pytest, pytest-cov, mypy, and sphinx-rtd-theme.

We can continue using `pip install -r requirements.txt` for all development purposes.  Downstream consumers (installing via pip, for instance) will only install the minimum runtime requirements.

This also reduces the total LOC by de-constantizing the strings that are used in only one place.  I also bumped the "lower than 3.6 and we have to exit" check to the very top.  No use in doing work if we're just going to exit out anyway.

Closes #466 

