### PR TITLE
Fix the title

### DIFF
--- a/docs/reference/subgraph.rst
+++ b/docs/reference/subgraph.rst
@@ -4,6 +4,6 @@ Subgraph
 .. currentmodule:: graspy.subgraph
 
 Signal-Subgraph Estimators
-------------------
+--------------------------
 
 .. autoclass:: SignalSubgraph


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes a documentation build warning that occurred with PR #322. 


#### What does this implement/fix? Explain your changes.
This PR extends the title underline to match the length of the text, and thereby resolves the documentation build warning

#### Any other comments?

