### PR TITLE
Run build on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: graspologic CI
-on: [push]
+on: [push, pull_request]
 jobs:
   build-documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In theory, simply adding pull_request to the list of triggers is all we need to run the build workflow on a forked repository.

Documentation: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories (scroll up a bit to read all of the PR content, but the "from forks" is the part we were failing at before)

I think this will work.  Of course, I thought `pull_request_target` would work too.