### PR TITLE
Update docs to show GM can accept negative entries in A, B

### DIFF
--- a/graspologic/match/gmp.py
+++ b/graspologic/match/gmp.py
@@ -157,10 +157,10 @@ class GraphMatch(BaseEstimator):
 
         Parameters
         ----------
-        A : 2d-array, square, positive
+        A : 2d-array, square
             A square adjacency matrix
 
-        B : 2d-array, square, positive
+        B : 2d-array, square
             A square adjacency matrix
 
         seeds_A : 1d-array, shape (m , 1) where m <= number of nodes (default = [])
@@ -330,11 +330,11 @@ class GraphMatch(BaseEstimator):
 
         Parameters
         ----------
-        A : 2d-array, square, positive
-            A square, positive adjacency matrix
+        A : 2d-array, square
+            A square adjacency matrix
 
-        B : 2d-array, square, positive
-            A square, positive adjacency matrix
+        B : 2d-array, square
+            A square adjacency matrix
 
         seeds_A : 1d-array, shape (m , 1) where m <= number of nodes (default = [])
             An array where each entry is an index of a node in `A`.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/CONTRIBUTING.md#how-to-create-an-actionable-bug-report
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #513 

#### What does this implement/fix? Explain your changes.
Remove the distinction from fit and fit_predict that A and B must be positive adjacency matrices

#### Any other comments?
