### PR TITLE
Updating joblib version to fix #582

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "seaborn>=0.9.0",
         "scikit-learn>=0.19.1",
         "scipy>=1.4.0",
+        "joblib>=0.17.0", # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "anytree>=2.8.0",
         "gensim",
         "hyppo>=0.1.3",
+        "joblib>=0.17.0", # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
         "matplotlib>=3.0.0,<=3.3.0",
         "networkx>=2.1",
         "numpy>=1.8.1",
@@ -58,7 +59,6 @@ setup(
         "seaborn>=0.9.0",
         "scikit-learn>=0.19.1",
         "scipy>=1.4.0",
-        "joblib>=0.17.0", # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Updated joblib version to fix parallelization issue that is Windows-specific.  Closes #582 