### PR TITLE
Add "Roles" to top of repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,8 @@ or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any addi
 # Issue Submission (Bug or Feature)
 
 We use GitHub issues to track all bugs and feature requests; feel free to open an issue if you have found a bug or wish 
-to see a feature implemented.
+to see a feature implemented. Please also feel free to tag one of the core 
+contributors (see our [Roles page](https://github.com/microsoft/graspologic/blob/dev/ROLES.md)).
 
 In case you experience issues using this package, do not hesitate to submit a ticket to our 
 [Issue Tracker](https://github.com/microsoft/graspologic/issues).  You are also welcome to post feature requests or pull

--- a/ROLES.md
+++ b/ROLES.md
@@ -1,0 +1,41 @@
+# Roles and Areas of Responsibility
+
+The following is a non-exhaustive list of the primary contributors to `graspologic` and 
+their roles and areas of responsibilities. Please feel free to use this list to `@` 
+specific contributors in your issues or pull requests that seem to line up best with 
+your issue! 
+
+## Core Contributors
+
+### Ali Saad-Eldin (@asaadeldin11)
+Ali is a Masters Student at Johns Hopkins University. He contributes and reviews code 
+mostly for the `match` and `embed` modules. 
+
+### Anton Alyakin (@alyakin314)
+Anton is an Assistant Research Engineer at Johns Hopkins University. His primary 
+contributions to `graspologic` are within `align` and `inference` modules. Ask him 
+anything about those.
+
+### Benjamin Pedigo (@bdpedigo)
+Ben is a PhD student at Johns Hopkins University in the NeuroData lab. Ask Ben about 
+network model fitting and sampling, clustering, and spectral embedding (`models`, 
+`simulations`, `cluster`, and `embed`, respectfully). Ben is also happy to hear how we 
+can improve our tutorials.
+
+### Carolyn Buractaon (@carolyncb)
+Carolyn is a Technical Program Manager at Microsoft. Ask Carolyn about where the project
+is going and how it’s organized.
+
+### Dwayne Pryce (@dwaynepryce)
+Dwayne Pryce is a Software Engineer at Microsoft Research. His primary contributions to
+`graspologic` are on the steering committee, quality of life utility functions, and
+build and release processes.
+
+### Jaewon Chung (@j1c)
+Jaewon is a PhD student at Johns Hopkins University. He is a maintainer and developer 
+for `graspologic`, and is responsible for reviewing code contributions, merging pull 
+requests, and making decisions on the `graspologic` API.
+
+### Nick Caurvina (@nyecarr)
+Nick is a Software Engineer at Microsoft Research. Ask Nick about the network 
+embeddings and their application to business problems.


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #531 

#### What does this implement/fix? Briefly explain your changes.
Adds the Roles and Responsibilities page to the actual repo as opposed to just the wiki.

#### Any other comments?
I think the wiki was not visible enough. Not sure where else in the package we should be directing people to this new page but I figured having it would be better than nothing. 

Really trying to wrap up #531 so let me know if anyone has any concerns. I know many people are out for break right now so no worries if this waits until people are back! Happy holidays.