### PR TITLE
Include participants in mouse data given to users

### DIFF
--- a/graspologic/datasets/base.py
+++ b/graspologic/datasets/base.py
@@ -176,5 +176,6 @@ def load_mice():
         atlas=atlas,
         blocks=blocks,
         features=features,
+        participants=participants,
         meta=meta,
     )

--- a/graspologic/datasets/base.py
+++ b/graspologic/datasets/base.py
@@ -133,6 +133,10 @@ def load_mice():
             DataFrame of block assignments for each ROI
         features : pd.DataFrame
             DataFrame of anatomical features for each ROI in each connectome
+        participants : pd.DataFrame
+            DataFrame of subject IDs and genotypes for each connectome
+        meta : Dictionary
+            Dictionary with meta information about the dataset (n_subjects and n_vertices)
 
     References
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

Currently, there's no data given to the user relating a mouse's subject ID to its genotype. This is not needed for most group-level analyses (omnibus embedding, clustering, etc.), but necessary if you want to analyze the anatomical data ([link](https://github.com/microsoft/graspologic/tree/dev/graspologic/datasets/mice/features)).

I've made a one-line change that gives the user access to `participants.csv`, a dataframe with genotype and subject id information.

#### Any other comments?
