### PR TITLE
Preparing a Makefile so that netlify can use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
+docs/_build
 docs/reference/_build/
 docs/tutorials/_build/
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,11 @@
+.PHONY: docs
+
+
+# Put it first so that "make" without argument is like "make help".
+docs:
+	cd reference && pip install -r requirements.txt && make html
+	cd tutorials && pip install -r requirements.txt && make html
+	mkdir -p _build/html
+	cp -r reference/_build/html _build/html/reference
+	cp -r tutorials/_build/html _build/html/tutorials
+


### PR DESCRIPTION
JHU had had some commands in the neurodata netlify build process for graspy/graspologic that didn't work anymore with our new split documentation setup.  @bdpedigo and I did a quick update of the build commands to use and I created a Makefile to call instead of having a bunch of separate commands shoved into their account.

In the long run we hope to retire netlify in favor of RTD but something is wrong with the RTD oauth and Github and I haven't had the time to dig into it yet.