### PR TITLE
prior to 0.22.0, scikit-learn did not expose gaussian mixture model t…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     numpy>=1.8.1
     POT>=0.7.0
     seaborn>= 0.11.0
-    scikit-learn>=0.19.1
+    scikit-learn>=0.22.0
     scipy>=1.4.0
     umap-learn>=0.4.6
 


### PR DESCRIPTION
Prior to 0.22.0, `scikit-learn` did not expose the gaussian mixture model classes/functions the same way in their namespace, so having a sklearn 0.18.3 or whatever would result in errors.

Closes #635.