### PR TITLE
Update broken link to the tutorial section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A graph, or network, provides a mathematically intuitive representation of data 
 # Documentation
 The official documentation with usage is at https://graspologic.readthedocs.io/en/latest/
 
-Please visit the [tutorial section](https://graspologic.readthedocs.io/en/latest/tutorial.html) in the official website for more in depth usage.
+Please visit the [tutorial section](https://microsoft.github.io/graspologic/tutorials/index.html) in the official website for more in depth usage.
 
 # System Requirements
 ## Hardware requirements


### PR DESCRIPTION
Update broken link to tutorial section where the documentation is now accessible.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

It just fixes the broken link in the README file.

#### Any other comments?
