### PR TITLE
Fix hyppo version to avoid import error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     anytree>=2.8.0
     gensim>=3.8.0,<=3.9.0  # methods signatures changed in the 4.0.0beta release
     graspologic-native
-    hyppo>=0.1.3
+    hyppo==0.1.3 # Newer versions of hyppo cause issue #659.
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,<=3.3.0
     networkx>=2.1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #659 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
Pins hyppo version to `0.1.3` to fix the bug when importing `hyppo._utils` caused by its new release.
