### PR TITLE
Initial commit of all contributors I could find in the contribution i…

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,5 @@
+{
+  "files": ["CONTRIBUTORS.md"],
+  "contributorsSortAlphabetically": true,
+  "contributors": ["asaadeldin11", "alyakin314", "AnshuTrivedi", "bdpedigo", "bryantower", "bvarjavand",  "carolyncb", "CaseyWeiner", "darkyed", "dfrancisco1998", "dtborders", "dwaynepryce", "ebridge2", "emasquil", "falkben", "gkang7", "hhelm10", "idc9", "j1c", "jdey4", "jheiko1", "jonmclean", "Jingyan230", "kareef928", "kikiwink", "loftusa", "nyecarr", "pauladkisson", "PerifanosPrometheus", "PSSF23", "rajpratyush", "rflperry", "SHAAAAN", "shaderein", "shiyussy", "spencer-loggia", "tathey1", "tliu68", "v715", "vikramc1", "vmdhhh", "zeou1"]
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,5 +1,5 @@
 {
   "files": ["CONTRIBUTORS.md"],
   "contributorsSortAlphabetically": true,
-  "contributors": ["asaadeldin11", "alyakin314", "AnshuTrivedi", "bdpedigo", "bryantower", "bvarjavand",  "carolyncb", "CaseyWeiner", "darkyed", "dfrancisco1998", "dtborders", "dwaynepryce", "ebridge2", "emasquil", "falkben", "gkang7", "hhelm10", "idc9", "j1c", "jdey4", "jheiko1", "jonmclean", "Jingyan230", "kareef928", "kikiwink", "loftusa", "nyecarr", "pauladkisson", "PerifanosPrometheus", "PSSF23", "rajpratyush", "rflperry", "SHAAAAN", "shaderein", "shiyussy", "spencer-loggia", "tathey1", "tliu68", "v715", "vikramc1", "vmdhhh", "zeou1"]
+  "contributors": ["asaadeldin11", "alyakin314", "AnshuTrivedi", "bdpedigo", "bryantower", "bvarjavand",  "carolyncb", "CaseyWeiner", "darkyed", "dfrancisco1998", "dtborders", "dwaynepryce", "ebridge2", "emasquil", "falkben", "gkang7", "hhelm10", "idc9", "j1c", "jdey4", "jheiko1", "jonmclean", "Jingyan230", "kareef928", "kikiwink", "loftusa", "pauladkisson", "PerifanosPrometheus", "PSSF23", "rajpratyush", "rflperry", "SHAAAAN", "shaderein", "shiyussy", "spencer-loggia", "tathey1", "tliu68", "v715", "vikramc1", "vmdhhh", "zeou1"]
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     anytree>=2.8.0
     gensim>=3.8.0,<=3.9.0  # methods signatures changed in the 4.0.0beta release
     graspologic-native
-    hyppo>=0.1.3
+    hyppo==0.1.3 # Newer versions of hyppo cause issue #659.
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,<=3.3.0
     networkx>=2.1


### PR DESCRIPTION
Not sure if I need anything else to enable this, but...

[All Contributors](https://allcontributors.org/) has a fancy github bot that should generate a `CONTRIBUTORS.md` file.  In an ideal world we could rely on the `Insights` tab on Github to tell us, but there are a number of people who participate in this project that either never directly contributed code (but whose work is still the bulk of a module in the repository) or have provided non-development support throughout the process, and whose work should absolutely be acknowledged.

The plan behind this bot is to be able to incorporate contributors who either didn't make a commit or, in some rare cases, whose commit got squashed out in a squash-merge (boo!).  In this way we can inform the all-contributors bot that the person should be included in our `CONTRIBUTORS.md` file.

I've never actually used this so I'm not sure when this triggers.  The current configuration, in theory, points to the file we want to generate (default is README, so we're overriding that to go to CONTRIBUTORS.md), alphabetize the list, and has a pre-generated list of contributors that I gleaned from Github's Insights tab for this project as well as individuals I know contributed code but got falsely attributed to me (@nyecarr and @bryantower specifically)