### PR TITLE
0.1.0 release notes

### DIFF
--- a/docs/reference/release.rst
+++ b/docs/reference/release.rst
@@ -5,14 +5,15 @@ Release Log
 
 graspologic 0.1.0
 -----------------
-This release represents the first release of the `GraSPy` and `topologic`_ libraries.
+This release represents the first release of the ``GraSPy`` and `topologic`_ libraries
+merger!
 
-In addition to all of the features that ``GraSPy`` had by version
-:ref:`release/release_0.3`, this release includes a number of feature enhancements and
-bug fixes - frankly, too many to go into.
+In addition to all of the features that ``GraSPy`` had in :ref:`last-graspy-label`,
+this release includes a number of feature enhancements and bug fixes - frankly, too
+many to go into.
 
-Please treat this as a brand new first release, informed heavily by the prior `GraSPy`,
-and extra special thanks to **all** of our
+Please treat this as a brand new first release, informed heavily by the prior
+``GraSPy``, and extra special thanks to **all** of our
 `contributors <https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTORS.md>`_!
 
 Previous GraSPy Releases

--- a/docs/reference/release.rst
+++ b/docs/reference/release.rst
@@ -5,64 +5,21 @@ Release Log
 
 graspologic 0.1.0
 -----------------
-Release date: ?
+This release represents the first release of the `GraSPy` and `topologic`_ libraries.
 
-GraSPy 0.3
-----------
-Release date: 04 Aug 2020
-Supports Python 3.6, and 3.7
+In addition to all of the features that ``GraSPy`` had by version
+:ref:`release/release_0.3`, this release includes a number of feature enhancements and
+bug fixes - frankly, too many to go into.
 
+Please treat this as a brand new first release, informed heavily by the prior `GraSPy`,
+and extra special thanks to **all** of our
+`contributors <https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTORS.md>`_!
+
+Previous GraSPy Releases
+------------------------
 .. toctree::
    :maxdepth: 1
 
-   release/release_0.3.rst
+   release/graspy_releases.rst
 
-GraSPy 0.2
-----------
-Release date: 02 Mar 2020
-Supports Python 3.5, 3.6, and 3.7
-
-.. toctree::
-   :maxdepth: 1
-
-   release/release_0.2.rst
-
-GraSPy 0.1
-----------
-Release date: 05 Aug 2019
-Supports Python 3.5, 3.6, and 3.7
-
-.. toctree::
-   :maxdepth: 1
-
-   release/release_0.1.rst
-
-GraSPy 0.0.3
-------------
-Release date: 11 June 2019
-Supports Python 3.5, 3.6, and 3.7.
-
-.. toctree::
-   :maxdepth: 1
-
-   release/release_0.0.3.rst
-
-GraSPy 0.0.2
-------------
-Release date: 26 March 2019
-Supports Python 3.5, 3.6, and 3.7.
-
-.. toctree::
-   :maxdepth: 1
-
-   release/release_0.0.2.rst
-
-GraSPy 0.0.1
-------------
-Release date: 14 December 2018
-Supports Python 3.5, 3.6, and 3.7.
-
-.. toctree::
-   :maxdepth: 1
-
-   release/release_0.0.1.rst
+.. _topologic: https://github.com/microsoft/topologic

--- a/docs/reference/release/graspy_releases.rst
+++ b/docs/reference/release/graspy_releases.rst
@@ -1,0 +1,62 @@
+GraSPy Release Log
+==================
+
+GraSPy 0.3
+----------
+Release date: 04 Aug 2020
+Supports Python 3.6, and 3.7
+
+.. toctree::
+   :maxdepth: 1
+
+   release_0.3.rst
+
+GraSPy 0.2
+----------
+Release date: 02 Mar 2020
+Supports Python 3.5, 3.6, and 3.7
+
+.. toctree::
+   :maxdepth: 1
+
+   release_0.2.rst
+
+GraSPy 0.1
+----------
+Release date: 05 Aug 2019
+Supports Python 3.5, 3.6, and 3.7
+
+.. toctree::
+   :maxdepth: 1
+
+   release_0.1.rst
+
+GraSPy 0.0.3
+------------
+Release date: 11 June 2019
+Supports Python 3.5, 3.6, and 3.7.
+
+.. toctree::
+   :maxdepth: 1
+
+   release_0.0.3.rst
+
+GraSPy 0.0.2
+------------
+Release date: 26 March 2019
+Supports Python 3.5, 3.6, and 3.7.
+
+.. toctree::
+   :maxdepth: 1
+
+   release_0.0.2.rst
+
+GraSPy 0.0.1
+------------
+Release date: 14 December 2018
+Supports Python 3.5, 3.6, and 3.7.
+
+.. toctree::
+   :maxdepth: 1
+
+   release_0.0.1.rst

--- a/docs/reference/release/release_0.3.rst
+++ b/docs/reference/release/release_0.3.rst
@@ -1,3 +1,5 @@
+.. _last-graspy-label:
+
 Release Notes: GraSPy 0.3
 =========================
 


### PR DESCRIPTION
Let's release 0.1.0.

I had grandiose plans to try to get every PR listed and every contributor within the release range and... it's just weird because we're effectively a new project that morphed from two old ones and I don't even know how to go about showing changelogs between them both.  

So we'll start fresh with 0.1.0 and have proper changelogs after that!

@bdpedigo in particular we will want to make sure any new changes after 0.1.0 will be put into the release notes/changelog  going forward.  We don't want to try to wrap these all up later, so we'll have each person submitting a PR add to the changelog as we go with something short but descriptive as we pull in PRs.