### PR TITLE
Adding a small checklist to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,11 @@ Thanks for contributing a pull request! Please ensure you have taken a look at
 the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
 -->
 
+[] Does this add any new dependencies?
+[] Does this modify any existing APIs?
+[] Is the change to the API backwards compatible?
+[] Have you built the documentation (reference and/or tutorial) and verified the document generated is appropriate?
+
 #### Reference Issues/PRs
 <!--
 Example: Fixes #1234. See also #3456.


### PR DESCRIPTION
Since versioning is now an important part of our PR process that we hadn't really had to worry about before, I wanted to make some additions to the PR template to (hopefully?) help speed up the resolution of any of those concerns by adding a checklist up front.

@saadhaxxan had a PR with a more robust checklist that we ended up not using at the time, but many of the items in that checklist would make sense to add in here. In the PR we closed (#493) we noted we'd need to add a checklist at some point, and we still haven't. 

In the short term I propose we take this small change, but we create an issue and agree on a set of items to have in the checklist.  I'd like to agree on the changes to this PR template in the short term, just so we have some operating procedures codified and can get back to working on all the fun stuff we have been working on instead.


