### PR TITLE
remove merger warning from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,6 @@
 - [License](#license)
 - [Issues](#issues)
 
-# Notice: `graspologic` is the merger project of `GraSPy` and `topologic`
-We're actively merging these projects into one, but you may see some references to `graspy` or `topologic` from time to time in documentation and
-issues. If you notice anything in the documentation referencing either graspy or topologic, please raise an issue (if one does not already exist)
-noting the missed titles so we can address all of them.
-
 # Overview
 A graph, or network, provides a mathematically intuitive representation of data with some sort of relationship between items. For example, a social network can be represented as a graph by considering all participants in the social network as nodes, with connections representing whether each pair of individuals in the network are friends with one another. Naively, one might apply traditional statistical techniques to a graph, which neglects the spatial arrangement of nodes within the network and is not utilizing all of the information present in the graph. In this package, we provide utilities and algorithms designed for the processing and analysis of graphs with specialized graph statistical algorithms.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![DOI](https://zenodo.org/badge/147768493.svg)](https://zenodo.org/badge/latestdoi/147768493)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-
 ## `graspologic` is a package for graph statistical algorithms.
 
 - [Overview](#overview)


### PR DESCRIPTION
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
None

#### What does this implement/fix? Briefly explain your changes.
Removes the warning from the readme about the merger

#### Any other comments?
I think we are safely at the point where there aren't any unresolved *merger-specific* issues like missing references to graspy or topologic that we have yet to notice. so i vote we remove this warning. 

We do still have a note about "History" [here](https://graspologic.readthedocs.io/en/latest/#history)