### PR TITLE
Enable better type hint errors

### DIFF
--- a/mypi.ini
+++ b/mypi.ini
@@ -1,2 +1,0 @@
-[mypy]
-ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,60 @@
+[mypy]
+warn_return_any = True
+warn_unused_configs = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+no_implicit_optional = True
+
+[mypy-anytree]
+ignore_missing_imports = True
+
+[mypy-hyppo.*]
+ignore_missing_imports = True
+
+[mypy-joblib]
+ignore_missing_imports = True
+
+[mypy-gensim.models]
+ignore_missing_imports = True
+
+[mypy-graspologic_native]
+# temporary until .pyi file added to native code
+ignore_missing_imports = True  
+
+[mypy-matplotlib]
+ignore_missing_imports = True
+
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-mpl_toolkits.*]
+ignore_missing_imports = True
+
+[mypy-numpy]
+ignore_missing_imports = True
+
+[mypy-networkx]
+ignore_missing_imports = True
+
+[mypy-ot]
+ignore_missing_imports = True
+
+[mypy-pandas]
+ignore_missing_imports = True
+
+[mypy-seaborn]
+ignore_missing_imports = True
+
+[mypy-scipy]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-sklearn.*]
+ignore_missing_imports = True
+
+[mypy-umap]
+ignore_missing_imports = True
+


### PR DESCRIPTION
While we slowly plug away at the `type-hint` branch, I wanted to get this updated mypy.ini config pushed first so that we could at least have some more actionable "type hinting is broken" error messages in our build-failed stuff.  @bdpedigo and @loftusa have been clamoring for this for aaaaaages so I finally buckled down and did it.

In this PR no code changes were done, but the [proper canonical config file](https://mypy.readthedocs.io/en/stable/config_file.html) was added instead of the old weird typo version, and we should now have a bunch of "oh man that's a lot of work" errors to sort through.


