### PR TITLE
Fixing a rare, division by 0 case

### DIFF
--- a/graspologic/layouts/nooverlap/_quad_node.py
+++ b/graspologic/layouts/nooverlap/_quad_node.py
@@ -1027,9 +1027,9 @@ class _QuadNode:
                 if 0 == denominator:
                     denominator = 0.00000001
                 value = (a ** 2 + b ** 2 - c ** 2) / denominator
-                if value > 1:
+                if value >= 1:
                     value = 0.999999
-                elif value < -1:
+                elif value <= -1:
                     value = -0.999999
                 angle_c = math.acos(value)
                 len_c_new = node_to_move.size + overlapping_node.size + _EPSILON


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->

- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

During the contraction phase of the no-overlap portion of the layout there is a case where we could have a divide by 0 error.
This change adjusts the new node position by a small amount.

#### Any other comments?
