### PR TITLE
Fix bug in MASE initial `n_components`

### DIFF
--- a/graspologic/embed/mase.py
+++ b/graspologic/embed/mase.py
@@ -129,8 +129,11 @@ class MultipleASE(BaseEmbedMulti):
         self.scaled = scaled
 
     def _reduce_dim(self, graphs):
-        # first embed into log2(n_vertices) for each graph
-        n_components = int(np.ceil(np.log2(np.min(self.n_vertices_))))
+        if self.n_components is None:
+            # first embed into log2(n_vertices) for each graph
+            n_components = int(np.ceil(np.log2(np.min(self.n_vertices_))))
+        else:
+            n_components = self.n_components
 
         # embed individual graphs
         embeddings = [

--- a/graspologic/embed/mase.py
+++ b/graspologic/embed/mase.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from .base import BaseEmbedMulti
 from .svd import select_dimension, selectSVD
+from .utils import is_almost_symmetric
 
 
 class MultipleASE(BaseEmbedMulti):

--- a/graspologic/embed/mase.py
+++ b/graspologic/embed/mase.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from .base import BaseEmbedMulti
 from .svd import select_dimension, selectSVD
-from .utils import is_almost_symmetric
+from ..utils import is_almost_symmetric
 
 
 class MultipleASE(BaseEmbedMulti):

--- a/graspologic/embed/mase.py
+++ b/graspologic/embed/mase.py
@@ -2,9 +2,7 @@
 # Licensed under the MIT License.
 
 import numpy as np
-from sklearn.utils.validation import check_is_fitted
 
-from ..utils import import_graph, is_almost_symmetric
 from .base import BaseEmbedMulti
 from .svd import select_dimension, selectSVD
 


### PR DESCRIPTION
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
 None

#### What does this implement/fix? Briefly explain your changes.
- Fixes a bug where if `n_components` was specified and > `int(np.ceil(np.log2(np.min(self.n_vertices_))))` then the initial embeddings were too small for what the user wanted
- removed unused imports

#### Any other comments?
Also avoids computing too many dimensions if not using automatic dimensionality selection