### PR TITLE
Deleted the cluster redundancy in reference

### DIFF
--- a/docs/reference/reference/index.rst
+++ b/docs/reference/reference/index.rst
@@ -10,7 +10,6 @@ Reference
    cluster
    datasets
    embed
-   cluster
    inference
    layouts
    match


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->

- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
This PR fixes the cluster tab redundancy in the graspologic reference: https://graspologic.readthedocs.io/en/latest/reference/index.html

#### Any other comments?
