### PR TITLE
Fix imports for hyppo >= 0.2.0

### DIFF
--- a/graspologic/inference/latent_distribution_test.py
+++ b/graspologic/inference/latent_distribution_test.py
@@ -62,12 +62,15 @@ def latent_distribution_test(
 
     metric : str or function (default="euclidean")
         Distance or a kernel metric to use, either a callable or a valid string.
-        If a callable, then it should behave similarly to either
+        Kernel metrics (e.g. "gaussian") must be used with kernel-based HSIC test
+        and distances (e.g. "euclidean") with all other tests. If a callable,
+        then it should behave similarly to either
         :func:`sklearn.metrics.pairwise_distances` or to
         :func:`sklearn.metrics.pairwise.pairwise_kernels`.
 
-        Valid strings for ``metric`` are, as defined in
+        Valid strings for distance ``metric`` are, as defined in
         :func:`sklearn.metrics.pairwise_distances`,
+
             - From scikit-learn: [``"euclidean"``, ``"cityblock"``, ``"cosine"``,
               ``"l1"``, ``"l2"``, ``"manhattan"``].
             - From scipy.spatial.distance: [``"braycurtis"``, ``"canberra"``,
@@ -77,19 +80,16 @@ def latent_distribution_test(
               ``"sokalmichener"``, ``"sokalsneath"``, ``"sqeuclidean"``,
               ``"yule"``] See the documentation for :mod:`scipy.spatial.distance` for
               details on these metrics.
-        Alternatively, this function computes the kernel similarity among the
-        samples within each data matrix.
 
-        Valid strings for ``compute_kernel`` are, as defined in
+        Valid strings for kernel ``metric`` are, as defined in
         :func:`sklearn.metrics.pairwise.pairwise_kernels`,
+
             [``"additive_chi2"``, ``"chi2"``, ``"linear"``, ``"poly"``,
             ``"polynomial"``, ``"rbf"``,
             ``"laplacian"``, ``"sigmoid"``, ``"cosine"``]
+
         Note ``"rbf"`` and ``"gaussian"`` are the same metric, which will use
         an adaptively selected bandwidth.
-
-        It is recommended to use kernels (e.g. "gaussian") with kernel-based HSIC test
-        and distances (e.g. "euclidean") with all other tests.
 
     n_components : int or None (default=None)
         Number of embedding dimensions. If None, the optimal embedding

--- a/graspologic/inference/latent_distribution_test.py
+++ b/graspologic/inference/latent_distribution_test.py
@@ -59,13 +59,13 @@ def latent_distribution_test(
         The two graphs, or their embeddings to run a hypothesis test on.
         Expected variable type and shape depends on input_graph attribute
 
-    test : str (default="hsic")
+    test : str (default="dcorr")
         Backend hypothesis test to use, one of ["cca", "dcorr", "hhg", "rv", "hsic", "mgc"].
         These tests are typically used for independence testing, but here they
         are used for a two-sample hypothesis test on the latent positions of
         two graphs. See :class:`hyppo.ksample.KSample` for more information.
 
-    metric : str or function (default="gaussian")
+    metric : str or function (default="euclidean")
         Distance or a kernel metric to use, either a callable or a valid string.
         If a callable, then it should behave similarly to either
         :func:`sklearn.metrics.pairwise_distances` or to

--- a/graspologic/inference/latent_distribution_test.py
+++ b/graspologic/inference/latent_distribution_test.py
@@ -362,7 +362,7 @@ def latent_distribution_test(
     if size_correction:
         X1_hat, X2_hat = _sample_modified_ase(X1_hat, X2_hat, pooled=pooled)
 
-    test_obj = KSample(test, compute_distance=metric)
+    test_obj = KSample(test, compute_distkern=metric)
 
     data = test_obj.test(X1_hat, X2_hat, reps=n_bootstraps, workers=workers, auto=False)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     anytree>=2.8.0
     gensim>=3.8.0,<=3.9.0  # methods signatures changed in the 4.0.0beta release
     graspologic-native
-    hyppo==0.1.3 # Newer versions of hyppo cause issue #659.
+    hyppo>=0.2.0
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,<=3.3.0
     networkx>=2.1

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -167,11 +167,11 @@ class TestLatentDistributionTest(unittest.TestCase):
         # assert len(record) == 0
         latent_distribution_test(A1, A2, test="hsic", metric="rbf")
         # some invalid combinations of test and metric
-        with pytest.warns(UserWarning):
+        with pytest.raises(ValueError):
             latent_distribution_test(A1, A2, "hsic", "euclidean")
-        with pytest.warns(UserWarning):
+        with pytest.raises(ValueError):
             latent_distribution_test(A1, A2, "dcorr", "gaussian")
-        with pytest.warns(UserWarning):
+        with pytest.raises(ValueError):
             latent_distribution_test(A1, A2, "dcorr", "rbf")
 
     def test_bad_matrix_inputs(self):


### PR DESCRIPTION
I'd like to use new `hyppo` features in versions >=0.2.0, and dealing with two versions of `hyppo` in environments is getting annoying.

#### Reference Issues/PRs
Fixes #659.

#### What does this implement/fix? Briefly explain your changes.
- Removed much of the code that deals with metric functions since `hyppo` now natively supports all options in [sklearn.metrics.pairwise.kernel_metrics](https://scikit-learn.org/dev/modules/generated/sklearn.metrics.pairwise.kernel_metrics.html#sklearn.metrics.pairwise.kernel_metrics) and [sklearn.metrics.pairwise.paired_distances](https://scikit-learn.org/dev/modules/generated/sklearn.metrics.pairwise.paired_distances.html#sklearn.metrics.pairwise.paired_distances). This way, we dont have to import the `gaussian` kernel function.
- Warning were raised when pairing kernel metrics + distance-based tests or distance metrics + kernel-based tests, which was introduced in #366. This behavior was changed so that kernel metrics must be paired with kernel-based test (HSIC), and similarly for distance. Otherwise, error is thrown.
  - Reasoning is that `hyppo` doesn't allow this mismatch so doesn't make sense for `graspologic` to allow mismatches.
- In #366, the defaults were "changed" to `test=HSIC` and `metric=gaussian`, but that was only changed in the docstring, not the actual code. Changed this back to `test=dcorr` and `metric=euclidean` in the docstring.
  - I dont have an opinion on what the actual default should be. But given that the code was never changed, I just changed the docstrings back. Perhaps outside of the scope of this PR to make this decision.
- Sorted imports