### PR TITLE
Add sparse matrix support for some matrix plotting functions

### DIFF
--- a/graspologic/plot/plot_matrix.py
+++ b/graspologic/plot/plot_matrix.py
@@ -589,13 +589,14 @@ def matrixplot(
     divider : AxesLocator
         Divider used to add new axes to the plot
     """
-    # check for the type and dimension of the data
-    _check_data(data)
-
+    
     # check for the plot type
     plot_type_opts = ["scattermap", "heatmap"]
     if plot_type not in plot_type_opts:
         raise ValueError(f"`plot_type` must be one of {plot_type_opts}")
+        
+    # check for the type and dimension of the data
+    _check_data(data)
 
     # check for the types of the sorting arguments
     (

--- a/graspologic/plot/plot_matrix.py
+++ b/graspologic/plot/plot_matrix.py
@@ -10,6 +10,7 @@ import matplotlib as mpl
 from matplotlib.colors import ListedColormap
 from scipy.sparse import csr_matrix
 
+
 def _check_data(data):
     if not isinstance(data, (np.ndarray, csr_matrix)):
         raise TypeError("Data must be a np.ndarray or scipy.sparse.csr_matrix.")
@@ -589,12 +590,12 @@ def matrixplot(
     divider : AxesLocator
         Divider used to add new axes to the plot
     """
-    
+
     # check for the plot type
     plot_type_opts = ["scattermap", "heatmap"]
     if plot_type not in plot_type_opts:
         raise ValueError(f"`plot_type` must be one of {plot_type_opts}")
-        
+
     # check for the type and dimension of the data
     _check_data(data)
 

--- a/graspologic/plot/plot_matrix.py
+++ b/graspologic/plot/plot_matrix.py
@@ -11,11 +11,17 @@ from matplotlib.colors import ListedColormap
 from scipy.sparse import csr_matrix
 
 
-def _check_data(data):
-    if not isinstance(data, (np.ndarray, csr_matrix)):
-        raise TypeError("Data must be a np.ndarray or scipy.sparse.csr_matrix.")
+def _check_data(data, plot_type):
+    if plot_type == 'scattermap':
+        if not isinstance(data, (np.ndarray, csr_matrix)):
+            raise TypeError("`data` must be a np.ndarray or scipy.sparse.csr_matrix.")
+    elif plot_type == 'heatmap':
+        if not isinstance(data, np.ndarray):
+            msg = "`data` must be a np.ndarray. If your data is a sparse matrix, please"
+            msg += " make sure that `plot_type` is set to 'scattermap'"
+            raise TypeError(msg) 
     if data.ndim != 2:
-        raise ValueError("Data must have dimension 2.")
+        raise ValueError("`data` must have dimension 2.")
 
 
 def _check_item_in_meta(meta, item, name):
@@ -521,7 +527,7 @@ def matrixplot(
     Parameters
     ----------
     data : np.ndarray or scipy.sparse.csr_matrix with ndim=2
-        Matrix to plot
+        Matrix to plot. Sparse matrix input is only accepted if ``plot_type == 'scattermap'``.
     ax : matplotlib axes object (default=None)
         Axes in which to draw the plot. If no axis is passed, one will be created.
     plot_type : str in {"heatmap", "scattermap"} (default="heatmap")
@@ -597,7 +603,7 @@ def matrixplot(
         raise ValueError(f"`plot_type` must be one of {plot_type_opts}")
 
     # check for the type and dimension of the data
-    _check_data(data)
+    _check_data(data, plot_type)
 
     # check for the types of the sorting arguments
     (
@@ -906,6 +912,7 @@ def adjplot(
     ----------
     data : np.ndarray or scipy.sparse.csr_matrix with ndim=2
         Matrix to plot, must be square.
+        Sparse matrix input is only accepted if ``plot_type == 'scattermap'``.
     ax : matplotlib axes object (default=None)
         Axes in which to draw the plot. If no axis is passed, one will be created.
     plot_type : str in {"heatmap", "scattermap"} (default="heatmap")

--- a/graspologic/plot/plot_matrix.py
+++ b/graspologic/plot/plot_matrix.py
@@ -8,11 +8,11 @@ import seaborn as sns
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import matplotlib as mpl
 from matplotlib.colors import ListedColormap
-
+from scipy.sparse import csr_matrix
 
 def _check_data(data):
-    if not isinstance(data, np.ndarray):
-        raise TypeError("Data must be a np.ndarray.")
+    if not isinstance(data, (np.ndarray, csr_matrix)):
+        raise TypeError("Data must be a np.ndarray or scipy.sparse.csr_matrix.")
     if data.ndim != 2:
         raise ValueError("Data must have dimension 2.")
 
@@ -387,7 +387,7 @@ def scattermap(data, ax=None, legend=False, sizes=(5, 10), **kws):
         _, ax = plt.subplots(1, 1, figsize=(20, 20))
     n_verts = data.shape[0]
     inds = np.nonzero(data)
-    edges = data[inds]
+    edges = np.squeeze(np.asarray(data[inds]))
     scatter_df = pd.DataFrame()
     scatter_df["weight"] = edges
     scatter_df["x"] = inds[1]

--- a/graspologic/plot/plot_matrix.py
+++ b/graspologic/plot/plot_matrix.py
@@ -362,7 +362,7 @@ def scattermap(data, ax=None, legend=False, sizes=(5, 10), **kws):
 
     Parameters
     ----------
-    data : np.narray, ndim=2
+    data : np.narray, scipy.sparse.csr_matrix, ndim=2
         Matrix to plot
     ax: matplotlib axes object, optional
         Axes in which to draw the plot, by default None
@@ -519,7 +519,7 @@ def matrixplot(
 
     Parameters
     ----------
-    data : np.ndarray with ndim=2
+    data : np.ndarray or scipy.sparse.csr_matrix with ndim=2
         Matrix to plot
     ax : matplotlib axes object (default=None)
         Axes in which to draw the plot. If no axis is passed, one will be created.
@@ -902,7 +902,7 @@ def adjplot(
 
     Parameters
     ----------
-    data : np.ndarray with ndim=2
+    data : np.ndarray or scipy.sparse.csr_matrix with ndim=2
         Matrix to plot, must be square.
     ax : matplotlib axes object (default=None)
         Axes in which to draw the plot. If no axis is passed, one will be created.

--- a/graspologic/plot/plot_matrix.py
+++ b/graspologic/plot/plot_matrix.py
@@ -12,14 +12,14 @@ from scipy.sparse import csr_matrix
 
 
 def _check_data(data, plot_type):
-    if plot_type == 'scattermap':
+    if plot_type == "scattermap":
         if not isinstance(data, (np.ndarray, csr_matrix)):
             raise TypeError("`data` must be a np.ndarray or scipy.sparse.csr_matrix.")
-    elif plot_type == 'heatmap':
+    elif plot_type == "heatmap":
         if not isinstance(data, np.ndarray):
             msg = "`data` must be a np.ndarray. If your data is a sparse matrix, please"
             msg += " make sure that `plot_type` is set to 'scattermap'"
-            raise TypeError(msg) 
+            raise TypeError(msg)
     if data.ndim != 2:
         raise ValueError("`data` must have dimension 2.")
 

--- a/tests/test_plot_matrix.py
+++ b/tests/test_plot_matrix.py
@@ -79,7 +79,7 @@ def test_adjplot_output():
 
 def test_adjplot_sparse():
     X = er_np(10, 0.5)
-    adjplot(csr_matrix(X), plot_type='scattermap')
+    adjplot(csr_matrix(X), plot_type="scattermap")
 
 
 def test_matrix_inputs():
@@ -189,6 +189,7 @@ def test_matrix_output():
         row_item_order="cell_size",
     )
 
+
 def test_matrixplot_sparse():
     X = er_np(10, 0.5)
-    adjplot(csr_matrix(X), plot_type='scattermap')
+    adjplot(csr_matrix(X), plot_type="scattermap")

--- a/tests/test_plot_matrix.py
+++ b/tests/test_plot_matrix.py
@@ -4,9 +4,9 @@
 import numpy as np
 import pandas as pd
 import pytest
-
 from graspologic.plot.plot_matrix import adjplot, matrixplot
 from graspologic.simulations.simulations import er_np
+from scipy.sparse import csr, csr_matrix
 
 
 def test_adjplot_inputs():
@@ -75,6 +75,11 @@ def test_adjplot_output():
     ax = adjplot(X, meta=meta, group="hemisphere")
     ax = adjplot(X, meta=meta, group="hemisphere", group_order="size")
     ax = adjplot(X, meta=meta, group="hemisphere", item_order="cell_size")
+
+
+def test_adjplot_sparse():
+    X = er_np(10, 0.5)
+    adjplot(csr_matrix(X), plot_type='scattermap')
 
 
 def test_matrix_inputs():
@@ -183,3 +188,7 @@ def test_matrix_output():
         col_group="hemisphere",
         row_item_order="cell_size",
     )
+
+def test_matrixplot_sparse():
+    X = er_np(10, 0.5)
+    adjplot(csr_matrix(X), plot_type='scattermap')


### PR DESCRIPTION
- [ ] Does this PR add any new dependencies?
- [x] Does this PR modify any existing APIs?
   - [x] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
None

#### What does this implement/fix? Briefly explain your changes.
- Allows the user to pass sparse matrices to `adjplot` and `matrixplot` when using the `scattermap` option

#### Any other comments?
- Could absolutely have a conversation about the best API for these functions. I'm not currently that happy with it, but don't want to let that hold up this PR.