### PR TITLE
Add a scipy sparse largest connected component finder

### DIFF
--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -548,7 +548,7 @@ def _largest_connected_component_adjacency(
     )
     if n_components > 1:
         unique_labels, counts = np.unique(labels, return_counts=True)
-        lcc_label_ind = np.argmax(counts)  # LCC is the component with the most nodes, 
+        lcc_label_ind = np.argmax(counts)  # LCC is the component with the most nodes,
         # so it is the component label with the highest count in the label array
 
         lcc_label = unique_labels[lcc_label_ind]  # grab the component label for the LCC

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -494,7 +494,6 @@ def largest_connected_component(
     return_inds: boolean, default: False
         Whether to return a np.ndarray containing the indices/nodes in the original
         adjacency matrix that were kept and are now in the returned graph.
-        Ignored when input is networkx object
 
     Returns
     -------
@@ -502,7 +501,7 @@ def largest_connected_component(
         New graph of the largest connected component, returned in the input format.
 
     inds: (optional)
-        Indices from the original adjacency matrix that were kept after taking
+        Indices/nodes from the original adjacency matrix that were kept after taking
         the largest connected component.
     """
 

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -543,10 +543,15 @@ def _largest_connected_component_adjacency(
     )
     if n_components > 1:
         unique_labels, counts = np.unique(labels, return_counts=True)
-        lcc_label_ind = np.argmax(counts)
-        lcc_label = unique_labels[lcc_label_ind]
-        lcc_mask = labels == lcc_label
-        lcc = adjacency[lcc_mask][:, lcc_mask]
+        lcc_label_ind = np.argmax(counts)  # LCC is the component with the most nodes, 
+        # so it is the component label with the highest count in the label array
+
+        lcc_label = unique_labels[lcc_label_ind]  # grab the component label for the LCC
+
+        lcc_mask = labels == lcc_label  # create a boolean mask arry for where the
+        # component labels equal that of the largest connected component
+        
+        lcc = adjacency[lcc_mask][:, lcc_mask]  # mask the adjacency matrix to only LCC
     else:
         lcc = adjacency
         lcc_mask = np.ones(adjacency.shape[0], dtype=bool)

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -471,7 +471,14 @@ def is_fully_connected(graph):
             return nx.is_weakly_connected(graph)
 
 
-def largest_connected_component(graph, return_inds=False):
+def largest_connected_component(
+    graph: Union[
+        nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph, np.ndarray, csr_matrix
+    ],
+    return_inds: bool = False,
+) -> Union[
+    nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph, np.ndarray, csr_matrix
+]:
     r"""
     Finds the largest connected component for the input graph.
 

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -548,9 +548,9 @@ def _largest_connected_component_adjacency(
 
         lcc_label = unique_labels[lcc_label_ind]  # grab the component label for the LCC
 
-        lcc_mask = labels == lcc_label  # create a boolean mask arry for where the
+        lcc_mask = labels == lcc_label  # create a boolean mask array for where the
         # component labels equal that of the largest connected component
-        
+
         lcc = adjacency[lcc_mask][:, lcc_mask]  # mask the adjacency matrix to only LCC
     else:
         lcc = adjacency

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -480,19 +480,19 @@ def largest_connected_component(graph, return_inds=False):
 
     Parameters
     ----------
-    graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray
-        Input graph in any of the above specified formats. If np.ndarray,
-        interpreted as an :math:`n \times n` adjacency matrix
+    graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray, scipy.sparse.csr_matrix
+        Input graph in any of the above specified formats. If np.ndarray or 
+        scipy.sparse.csr_matrix interpreted as an :math:`n \times n` adjacency matrix.
 
     return_inds: boolean, default: False
-        Whether to return a np.ndarray containing the indices in the original
+        Whether to return a np.ndarray containing the indices/nodes in the original
         adjacency matrix that were kept and are now in the returned graph.
         Ignored when input is networkx object
 
     Returns
     -------
-    graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray
-        New graph of the largest connected component of the input parameter.
+    graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray, scipy.sparse.csr_matrix
+        New graph of the largest connected component, returned in the input format.
 
     inds: (optional)
         Indices from the original adjacency matrix that were kept after taking

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -485,9 +485,9 @@ def largest_connected_component(graph, return_inds=False):
         scipy.sparse.csr_matrix interpreted as an :math:`n \times n` adjacency matrix.
 
     return_inds: boolean, default: False
-        Whether to return a np.ndarray containing the indices/nodes in the original
+        Whether to return a np.ndarray containing the indices of the original
         adjacency matrix that were kept and are now in the returned graph.
-        Ignored when input is networkx object
+        Ignored when input is networkx object.
 
     Returns
     -------
@@ -500,7 +500,7 @@ def largest_connected_component(graph, return_inds=False):
     """
 
     if isinstance(graph, (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)):
-        return _largest_connected_component_networkx(graph, return_inds=return_inds)
+        return _largest_connected_component_networkx(graph)
     elif isinstance(graph, (np.ndarray, csr_matrix)):
         return _largest_connected_component_adjacency(graph, return_inds=return_inds)
     else:
@@ -513,7 +513,6 @@ def largest_connected_component(graph, return_inds=False):
 
 def _largest_connected_component_networkx(
     graph: Union[nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph],
-    return_inds: bool = False,
 ):
     if type(graph) in [nx.Graph, nx.MultiGraph]:
         lcc_nodes = max(nx.connected_components(graph), key=len)
@@ -521,12 +520,7 @@ def _largest_connected_component_networkx(
         lcc_nodes = max(nx.weakly_connected_components(graph), key=len)
     lcc = graph.subgraph(lcc_nodes).copy()
     lcc.remove_nodes_from([n for n in lcc if n not in lcc_nodes])
-    if return_inds:
-        nodelist = np.array(list(lcc_nodes))
-    if return_inds:
-        return lcc, nodelist
-    else:
-        return lcc
+    return lcc
 
 
 def _largest_connected_component_adjacency(

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -543,7 +543,7 @@ def _largest_connected_component_adjacency(
     )
     if n_components > 1:
         unique_labels, counts = np.unique(labels, return_counts=True)
-        lcc_label_ind = np.argmax(counts)  # LCC is the component with the most nodes,
+        lcc_label_ind = np.argmax(counts)  # LCC is the component with the most nodes, 
         # so it is the component label with the highest count in the label array
 
         lcc_label = unique_labels[lcc_label_ind]  # grab the component label for the LCC

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -543,7 +543,7 @@ def _largest_connected_component_adjacency(
     )
     if n_components > 1:
         unique_labels, counts = np.unique(labels, return_counts=True)
-        lcc_label_ind = np.argmax(counts)  # LCC is the component with the most nodes, 
+        lcc_label_ind = np.argmax(counts)  # LCC is the component with the most nodes,
         # so it is the component label with the highest count in the label array
 
         lcc_label = unique_labels[lcc_label_ind]  # grab the component label for the LCC

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -492,9 +492,9 @@ def largest_connected_component(
         scipy.sparse.csr_matrix interpreted as an :math:`n \times n` adjacency matrix.
 
     return_inds: boolean, default: False
-        Whether to return a np.ndarray containing the indices of the original
+        Whether to return a np.ndarray containing the indices/nodes in the original
         adjacency matrix that were kept and are now in the returned graph.
-        Ignored when input is networkx object.
+        Ignored when input is networkx object
 
     Returns
     -------
@@ -507,7 +507,7 @@ def largest_connected_component(
     """
 
     if isinstance(graph, (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)):
-        return _largest_connected_component_networkx(graph)
+        return _largest_connected_component_networkx(graph, return_inds=return_inds)
     elif isinstance(graph, (np.ndarray, csr_matrix)):
         return _largest_connected_component_adjacency(graph, return_inds=return_inds)
     else:
@@ -520,6 +520,7 @@ def largest_connected_component(
 
 def _largest_connected_component_networkx(
     graph: Union[nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph],
+    return_inds: bool = False,
 ):
     if type(graph) in [nx.Graph, nx.MultiGraph]:
         lcc_nodes = max(nx.connected_components(graph), key=len)
@@ -527,7 +528,12 @@ def _largest_connected_component_networkx(
         lcc_nodes = max(nx.weakly_connected_components(graph), key=len)
     lcc = graph.subgraph(lcc_nodes).copy()
     lcc.remove_nodes_from([n for n in lcc if n not in lcc_nodes])
-    return lcc
+    if return_inds:
+        nodelist = np.array(list(lcc_nodes))
+    if return_inds:
+        return lcc, nodelist
+    else:
+        return lcc
 
 
 def _largest_connected_component_adjacency(

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -481,7 +481,7 @@ def largest_connected_component(graph, return_inds=False):
     Parameters
     ----------
     graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray, scipy.sparse.csr_matrix
-        Input graph in any of the above specified formats. If np.ndarray or 
+        Input graph in any of the above specified formats. If np.ndarray or
         scipy.sparse.csr_matrix interpreted as an :math:`n \times n` adjacency matrix.
 
     return_inds: boolean, default: False
@@ -531,9 +531,10 @@ def _largest_connected_component_adjacency(
     adjacency: Union[np.ndarray, csr_matrix],
     return_inds: bool = False,
 ):
-    # weakly connected has the same definition as if the graph were undirected
-    # I don't know whether doing the exhaustive directed check is worth it here
-    # so I wrote it like this to basically assume directed
+    # If you treat an undirected graph as directed and take the largest weakly connected
+    # component, you'll get the same answer as taking the largest connected component of
+    # that undirected graph. So I wrote it this way to avoid the cost of checking for
+    # directedness, and it makes the code simpler too.
     n_components, labels = csgraph.connected_components(
         adjacency, directed=True, connection="weak", return_labels=True
     )
@@ -543,9 +544,12 @@ def _largest_connected_component_adjacency(
         lcc_label = unique_labels[lcc_label_ind]
         lcc_mask = labels == lcc_label
         lcc = adjacency[lcc_mask][:, lcc_mask]
+    else:
+        lcc = adjacency
+        lcc_mask = np.ones(adjacency.shape[0], dtype=bool)
 
     if return_inds:
-        all_inds = np.arange(len(adjacency))
+        all_inds = np.arange(adjacency.shape[0])
         lcc_inds = all_inds[lcc_mask]
         return lcc, lcc_inds
     else:

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -504,8 +504,10 @@ def largest_connected_component(graph, return_inds=False):
     elif isinstance(graph, (np.ndarray, csr_matrix)):
         return _largest_connected_component_adjacency(graph, return_inds=return_inds)
     else:
-        msg = "`graph` must either be a networkx graph or an adjacency matrix in"
-        msg += " numpy ndarray or scipy csr_matrix format."
+        msg = (
+            "`graph` must either be a networkx graph or an adjacency matrix in"
+            " numpy ndarray or scipy csr_matrix format."
+        )
         raise TypeError(msg)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,10 +7,10 @@ from math import sqrt
 import networkx as nx
 import numpy as np
 import pytest
-from numpy.testing import assert_equal
-
 from graspologic.utils import remap_labels
 from graspologic.utils import utils as gus
+from numpy.testing import assert_equal
+from scipy.sparse import csr_matrix
 
 
 class TestInput(unittest.TestCase):
@@ -236,6 +236,36 @@ class TestLCC(unittest.TestCase):
         np.testing.assert_array_equal(nodelist, expected_nodelist)
         lcc_matrix = gus.largest_connected_component(g)
         np.testing.assert_array_equal(lcc_matrix, expected_lcc_matrix)
+
+    def test_lcc_scipy(self):
+        expected_lcc_matrix = np.array(
+            [
+                [0, 1, 1, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 1],
+                [0, 1, 0, 0, 0],
+                [0, 0, 1, 0, 0],
+            ]
+        )
+        expected_nodelist = np.array([0, 1, 2, 3, 5])
+        adjacency = np.array(
+            [
+                [0, 1, 1, 0, 0, 0, 0],  # connected
+                [0, 0, 0, 0, 0, 0, 0],  # connected
+                [0, 0, 0, 1, 0, 1, 0],  # connected
+                [0, 1, 0, 0, 0, 0, 0],  # connected
+                [0, 0, 0, 0, 0, 0, 0],  # not connected
+                [0, 0, 1, 0, 0, 0, 0],  # connected
+                [0, 0, 0, 0, 0, 0, 0],  # not connected
+            ]
+        )
+        sparse_adjacency = csr_matrix(adjacency)
+
+        lcc_matrix, nodelist = gus.largest_connected_component(
+            sparse_adjacency, return_inds=True
+        )
+        np.testing.assert_array_equal(lcc_matrix.toarray(), expected_lcc_matrix)
+        np.testing.assert_array_equal(nodelist, expected_nodelist)
 
     def test_multigraph_lcc_numpystack(self):
         expected_g_matrix = np.array(


### PR DESCRIPTION
- [ ] Does this PR add any new dependencies?
- [x] Does this PR modify any existing APIs?
   - [x] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
Fixes #791 

We also discussed in #655 

#### What does this implement/fix? Briefly explain your changes.
- Adds support for scipy sparse adjacency matrices in `largest_connected_component`
- Uses this function for numpy ndarray inputs as well

#### Any other comments?
- We could also fix up `multigraph_lcc_intersection` and `multigraph_lcc_union`. Someone is welcome to open a separate issue and add that if so desired, it would be good to have for consistency's sake too. 

cc: @dlee0156