### PR TITLE
fix matplotlib version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     graspologic-native>=1.0.0
     hyppo>=0.2.0
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
-    matplotlib>=3.0.0,<=3.3.0
+    matplotlib>=3.0.0
     networkx>=2.1
     numpy>=1.8.1
     POT>=0.7.0


### PR DESCRIPTION
See #809.
Ignore if there's a good reason for clipping the version.