### PR TITLE
Allow int in xticklabels

### DIFF
--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -262,7 +262,7 @@ def heatmap(
         if len(xticklabels) != X.shape[1]:
             msg = "xticklabels must have same length {}.".format(X.shape[1])
             raise ValueError(msg)
-    elif not isinstance(xticklabels, bool):
+    elif not isinstance(xticklabels, (bool, int)):
         msg = "xticklabels must be a bool or a list, not {}".format(type(xticklabels))
         raise TypeError(msg)
 


### PR DESCRIPTION
Small change.
Seaborn's heatmap lets you put an `int` into xticklabels. There's no reason we shouldn't as well.