### PR TITLE
Unittest transition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
           pip install -U pip setuptools
           pip install -r requirements.txt
           black --check --diff ./graspologic ./tests
+          isort --check-only ./graspologic ./tests
   mypy-type-check:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,24 @@ branch. Steps:
    Always use a `feature` branch. Pull requests directly to either `dev` or `main` will be rejected
    until you create a feature branch based on `dev`.
 
-4. Develop the feature on your feature branch. Add changed files using `git add` and then `git commit` files:
+4. Unit testing
+
+   It's important to write unit tests for your bug fix and your features. When fixing a bug, first create a test that explicitly exercises the bug and results in a test case failure.  Then create the fix and run the test again to verify your results.
+
+   For new features, we advocate using [TDD](https://en.wikipedia.org/wiki/Test-driven_development) wherever possible.
+
+   We also explicitly ask that you hew toward the `unittest` Python module for conformance.  This will ensure it plays nicely with most common IDEs on the market.
+
+6. Code formatting:
+   It's important to us that you follow the standards of our project.  Please use `black` and `isort` prior to
+   committing.
+
+   ```bash
+   black graspologic/ tests/
+   isort graspologic/ tests/
+   ```
+
+7. Develop the feature on your feature branch. Add changed files using `git add` and then `git commit` files:
 
    ```bash
    git add modified_files
@@ -120,8 +137,9 @@ We recommended that your contribution complies with the following rules before y
   [`typehinting`](https://docs.python.org/3/library/typing.html). Validate your typehinting by running `mypy ./graspologic`
 - All code should be automatically formatted by `black`. You can run this formatter by calling:
   ```bash
-  pip install black
+  pip install black isort
   black path/to/your_module.py
+  isort path/to/your_module.py
   ```
 - Ensure all tests are passing locally using `pytest`. Install the necessary
   packages by: 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ coverage:
 
 lint:
 	black --check --diff ./graspologic ./tests
-
+	isort --check-only ./graspologic ./tests
+format:
+	black ./graspologic ./tests
+	isort ./graspologic ./tests
 test:
 	pytest tests
 

--- a/graspologic/__init__.py
+++ b/graspologic/__init__.py
@@ -11,12 +11,11 @@ import graspologic.models
 import graspologic.nominate
 import graspologic.partition
 import graspologic.pipeline
-import graspologic.preprocessing
 import graspologic.plot
+import graspologic.preprocessing
 import graspologic.simulations
 import graspologic.subgraph
 import graspologic.utils
-
 from graspologic.version import __version
 
 __version__ = __version()

--- a/graspologic/align/base.py
+++ b/graspologic/align/base.py
@@ -1,10 +1,11 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import numpy as np
 from abc import abstractmethod
-from sklearn.utils import check_array
+
+import numpy as np
 from sklearn.base import BaseEstimator
+from sklearn.utils import check_array
 
 
 class BaseAlign(BaseEstimator):

--- a/graspologic/align/seedless_procrustes.py
+++ b/graspologic/align/seedless_procrustes.py
@@ -1,13 +1,13 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import ot
 import numpy as np
+import ot
 from sklearn.utils import check_array
 
 from .base import BaseAlign
-from .sign_flips import SignFlips
 from .orthogonal_procrustes import OrthogonalProcrustes
+from .sign_flips import SignFlips
 
 
 class SeedlessProcrustes(BaseAlign):

--- a/graspologic/cluster/__init__.py
+++ b/graspologic/cluster/__init__.py
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-from .gclust import GaussianCluster
-from .kclust import KMeansCluster
 from .autogmm import AutoGMMCluster
 from .divisive_cluster import DivisiveCluster
+from .gclust import GaussianCluster
+from .kclust import KMeansCluster
 
 __all__ = ["GaussianCluster", "KMeansCluster", "AutoGMMCluster", "DivisiveCluster"]

--- a/graspologic/cluster/autogmm.py
+++ b/graspologic/cluster/autogmm.py
@@ -1,9 +1,13 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
+import warnings
+
 import numpy as np
 import pandas as pd
+from joblib import Parallel, delayed
 from sklearn.cluster import AgglomerativeClustering
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.metrics import adjusted_rand_score
 from sklearn.mixture import GaussianMixture
 from sklearn.mixture._gaussian_mixture import (
@@ -11,11 +15,6 @@ from sklearn.mixture._gaussian_mixture import (
     _estimate_gaussian_parameters,
 )
 from sklearn.model_selection import ParameterGrid
-
-from sklearn.exceptions import ConvergenceWarning
-
-from joblib import Parallel, delayed
-import warnings
 
 from .base import BaseCluster
 

--- a/graspologic/cluster/divisive_cluster.py
+++ b/graspologic/cluster/divisive_cluster.py
@@ -2,12 +2,11 @@
 # Licensed under the MIT License.
 
 import numpy as np
+from anytree import LevelOrderIter, NodeMixin
 from sklearn.base import BaseEstimator
 from sklearn.mixture import GaussianMixture
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
-
-from anytree import NodeMixin, LevelOrderIter
 
 from .autogmm import AutoGMMCluster
 from .kclust import KMeansCluster

--- a/graspologic/embed/__init__.py
+++ b/graspologic/embed/__init__.py
@@ -2,16 +2,15 @@
 # Licensed under the MIT License.
 
 from .ase import AdjacencySpectralEmbed
+from .base import BaseSpectralEmbed
+from .case import CovariateAssistedEmbed
 from .lse import LaplacianSpectralEmbed
 from .mase import MultipleASE
 from .mds import ClassicalMDS
+from .mug2vec import mug2vec
 from .n2v import node2vec_embed
 from .omni import OmnibusEmbed
 from .svd import select_dimension, select_svd
-from .base import BaseSpectralEmbed
-from .mug2vec import mug2vec
-from .case import CovariateAssistedEmbed
-
 
 __all__ = [
     "ClassicalMDS",

--- a/graspologic/embed/ase.py
+++ b/graspologic/embed/ase.py
@@ -3,8 +3,8 @@
 
 from typing import Optional
 
-from .base import BaseSpectralEmbed
 from ..utils import augment_diagonal
+from .base import BaseSpectralEmbed
 
 
 class AdjacencySpectralEmbed(BaseSpectralEmbed):

--- a/graspologic/embed/base.py
+++ b/graspologic/embed/base.py
@@ -10,13 +10,13 @@ import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted
 
-from .svd import select_svd
 from ..utils import (
     augment_diagonal,
     import_graph,
     is_almost_symmetric,
     is_fully_connected,
 )
+from .svd import select_svd
 
 
 class BaseSpectralEmbed(BaseEstimator):

--- a/graspologic/embed/case.py
+++ b/graspologic/embed/case.py
@@ -1,10 +1,11 @@
+from typing import Callable, Optional, Tuple
+
 import numpy as np
 from scipy.sparse.linalg import LinearOperator, eigsh
 from sklearn.preprocessing import normalize, scale
-from typing import Tuple, Callable, Optional
 
-from graspologic.utils import import_graph, to_laplacian, is_almost_symmetric
 from graspologic.embed.base import BaseSpectralEmbed
+from graspologic.utils import import_graph, is_almost_symmetric, to_laplacian
 
 
 class CovariateAssistedEmbed(BaseSpectralEmbed):

--- a/graspologic/embed/lse.py
+++ b/graspologic/embed/lse.py
@@ -2,13 +2,13 @@
 # Licensed under the MIT License.
 
 
-from .base import BaseSpectralEmbed
-from ..utils import to_laplacian
+from typing import Optional, Union
 
+import networkx as nx
 import numpy as np
 
-from typing import Optional, Union
-import networkx as nx
+from ..utils import to_laplacian
+from .base import BaseSpectralEmbed
 
 
 class LaplacianSpectralEmbed(BaseSpectralEmbed):

--- a/graspologic/embed/mase.py
+++ b/graspologic/embed/mase.py
@@ -5,9 +5,9 @@ from typing import Optional
 
 import numpy as np
 
+from ..utils import is_almost_symmetric
 from .base import BaseEmbedMulti
 from .svd import select_dimension, select_svd
-from ..utils import is_almost_symmetric
 
 
 class MultipleASE(BaseEmbedMulti):

--- a/graspologic/embed/mds.py
+++ b/graspologic/embed/mds.py
@@ -7,8 +7,8 @@ import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.utils import check_array
 
-from .svd import select_svd
 from ..utils import is_symmetric
+from .svd import select_svd
 
 
 def _get_centering_matrix(n):

--- a/graspologic/embed/mug2vec.py
+++ b/graspologic/embed/mug2vec.py
@@ -6,9 +6,9 @@ from typing import Optional
 import numpy as np
 from sklearn.base import BaseEstimator
 
+from ..utils import pass_to_ranks
 from .mds import ClassicalMDS
 from .omni import OmnibusEmbed
-from ..utils import pass_to_ranks
 
 
 class mug2vec(BaseEstimator):

--- a/graspologic/embed/omni.py
+++ b/graspologic/embed/omni.py
@@ -2,14 +2,13 @@
 # Licensed under the MIT License.
 
 import warnings
-
 from typing import Optional
 
 import numpy as np
+from scipy.sparse import isspmatrix_csr
 
 from ..utils import import_graph, is_fully_connected
 from .base import BaseEmbedMulti
-from scipy.sparse import isspmatrix_csr
 
 
 def _get_omni_matrix(graphs):

--- a/graspologic/embed/svd.py
+++ b/graspologic/embed/svd.py
@@ -6,8 +6,9 @@ from typing import Optional
 import numpy as np
 import scipy
 import sklearn
-from scipy.stats import norm
 from scipy.sparse import isspmatrix_csr
+from scipy.stats import norm
+
 from graspologic.utils import is_almost_symmetric
 
 

--- a/graspologic/inference/__init__.py
+++ b/graspologic/inference/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-from .latent_position_test import latent_position_test
 from .latent_distribution_test import latent_distribution_test
+from .latent_position_test import latent_position_test
 
 __all__ = ["latent_position_test", "latent_distribution_test"]

--- a/graspologic/layouts/__init__.py
+++ b/graspologic/layouts/__init__.py
@@ -1,10 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from .auto import layout_tsne, layout_umap
 from .classes import NodePosition
 from .colors import categorical_colors, sequential_colors
 from .render import save_graph, show_graph
-from .auto import layout_tsne, layout_umap
 
 __all__ = [
     "NodePosition",

--- a/graspologic/layouts/__init__.py
+++ b/graspologic/layouts/__init__.py
@@ -1,10 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from .auto import layout_tsne, layout_umap
+
 from .classes import NodePosition
 from .colors import categorical_colors, sequential_colors
 from .render import save_graph, show_graph
+
+from .auto import layout_tsne, layout_umap  # isort:skip
 
 __all__ = [
     "NodePosition",

--- a/graspologic/layouts/__main__.py
+++ b/graspologic/layouts/__main__.py
@@ -3,13 +3,13 @@
 
 import argparse
 import logging
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import Any, Dict, List
 
 import networkx as nx
 
-from . import auto, NodePosition, render
+from . import NodePosition, auto, render
 from .colors import categorical_colors
 
 

--- a/graspologic/layouts/colors.py
+++ b/graspologic/layouts/colors.py
@@ -2,16 +2,16 @@
 # Licensed under the MIT license.
 
 import atexit
-from itertools import cycle
 import json
 import math
-import numpy as np
 import os
+from itertools import cycle
 from pathlib import Path
-import pkg_resources
-from sklearn.preprocessing import minmax_scale
 from typing import Any, Dict, Optional, Tuple
 
+import numpy as np
+import pkg_resources
+from sklearn.preprocessing import minmax_scale
 
 __all__ = ["categorical_colors", "sequential_colors"]
 

--- a/graspologic/layouts/nooverlap/__init__.py
+++ b/graspologic/layouts/nooverlap/__init__.py
@@ -4,5 +4,4 @@
 
 from graspologic.layouts.nooverlap.nooverlap import remove_overlaps
 
-
 __all__ = ["remove_overlaps"]

--- a/graspologic/layouts/nooverlap/_quad_node.py
+++ b/graspologic/layouts/nooverlap/_quad_node.py
@@ -1,13 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from graspologic.layouts.classes import NodePosition
-import math
 import logging
-from sklearn.preprocessing import normalize
-import numpy as np
+import math
 
+import numpy as np
 from scipy.spatial import distance
+from sklearn.preprocessing import normalize
+
+from graspologic.layouts.classes import NodePosition
 
 _EPSILON = 0.001
 logger = logging.getLogger(__name__)

--- a/graspologic/layouts/nooverlap/nooverlap.py
+++ b/graspologic/layouts/nooverlap/nooverlap.py
@@ -5,9 +5,9 @@ import logging
 import time
 from typing import List
 
+from .. import NodePosition
 from ._node import _Node
 from ._quad_tree import _QuadTree
-from .. import NodePosition
 
 logger = logging.getLogger(__name__)
 

--- a/graspologic/layouts/render.py
+++ b/graspologic/layouts/render.py
@@ -1,10 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import networkx as nx
 from typing import Any, Dict, List, Optional, Tuple
-from graspologic.layouts.classes import NodePosition
+
 import matplotlib.pyplot as plt
+import networkx as nx
+
+from graspologic.layouts.classes import NodePosition
 
 
 def _calculate_x_y_domain(

--- a/graspologic/models/__init__.py
+++ b/graspologic/models/__init__.py
@@ -2,9 +2,9 @@
 # Licensed under the MIT License.
 
 from .base import BaseGraphEstimator
-from .er import EREstimator, DCEREstimator
-from .sbm_estimators import SBMEstimator, DCSBMEstimator
+from .er import DCEREstimator, EREstimator
 from .rdpg import RDPGEstimator
+from .sbm_estimators import DCSBMEstimator, SBMEstimator
 
 __all__ = [
     "BaseGraphEstimator",

--- a/graspologic/models/base.py
+++ b/graspologic/models/base.py
@@ -7,8 +7,8 @@ import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted
 
-from ..utils import import_graph, is_unweighted
 from ..simulations import sample_edges
+from ..utils import import_graph, is_unweighted
 
 
 def _calculate_p(block):

--- a/graspologic/models/er.py
+++ b/graspologic/models/er.py
@@ -1,9 +1,10 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-from .sbm_estimators import SBMEstimator, DCSBMEstimator
-from ..utils import import_graph
 import numpy as np
+
+from ..utils import import_graph
+from .sbm_estimators import DCSBMEstimator, SBMEstimator
 
 
 class EREstimator(SBMEstimator):

--- a/graspologic/models/rdpg.py
+++ b/graspologic/models/rdpg.py
@@ -3,10 +3,10 @@
 
 import numpy as np
 
-from .base import BaseGraphEstimator
 from ..embed import AdjacencySpectralEmbed
 from ..simulations import p_from_latent
-from ..utils import import_graph, augment_diagonal, is_unweighted
+from ..utils import augment_diagonal, import_graph, is_unweighted
+from .base import BaseGraphEstimator
 
 
 class RDPGEstimator(BaseGraphEstimator):

--- a/graspologic/nominate/VNviaSGM.py
+++ b/graspologic/nominate/VNviaSGM.py
@@ -1,8 +1,10 @@
-import numpy as np
-from ..match import GraphMatch as GMP
-from sklearn.base import BaseEstimator
 import itertools
 import warnings
+
+import numpy as np
+from sklearn.base import BaseEstimator
+
+from ..match import GraphMatch as GMP
 
 
 class VNviaSGM(BaseEstimator):

--- a/graspologic/nominate/spectralVN.py
+++ b/graspologic/nominate/spectralVN.py
@@ -1,12 +1,13 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-from typing import Union, Tuple
-from ..embed import BaseSpectralEmbed
-from ..embed import AdjacencySpectralEmbed, LaplacianSpectralEmbed
+from typing import Tuple, Union
+
 import numpy as np
-from sklearn.neighbors import NearestNeighbors
 from sklearn.base import BaseEstimator
+from sklearn.neighbors import NearestNeighbors
+
+from ..embed import AdjacencySpectralEmbed, BaseSpectralEmbed, LaplacianSpectralEmbed
 
 
 class SpectralVertexNomination(BaseEstimator):

--- a/graspologic/partition/__init__.py
+++ b/graspologic/partition/__init__.py
@@ -1,9 +1,8 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-from .modularity import modularity, modularity_components
 from .leiden import HierarchicalCluster, hierarchical_leiden, leiden
-
+from .modularity import modularity, modularity_components
 
 __all__ = [
     "HierarchicalCluster",

--- a/graspologic/partition/leiden.py
+++ b/graspologic/partition/leiden.py
@@ -2,12 +2,13 @@
 # Licensed under the MIT license.
 
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+
+import graspologic_native as gn
 import networkx as nx
 import numpy as np
 import scipy
-from .. import utils
 
-import graspologic_native as gn
+from .. import utils
 
 
 def _validate_and_build_edge_list(

--- a/graspologic/partition/modularity.py
+++ b/graspologic/partition/modularity.py
@@ -2,9 +2,10 @@
 # Licensed under the MIT license.
 
 import math
-import networkx as nx
 from collections import defaultdict
 from typing import Any, Dict
+
+import networkx as nx
 
 
 def _modularity_component(

--- a/graspologic/pipeline/__init__.py
+++ b/graspologic/pipeline/__init__.py
@@ -19,5 +19,4 @@ is to bridge this gap.
 # Licensed under the MIT license.
 
 from . import embed
-
 from .graph_builder import GraphBuilder

--- a/graspologic/pipeline/embed/_elbow.py
+++ b/graspologic/pipeline/embed/_elbow.py
@@ -5,7 +5,6 @@
 from typing import List, Tuple, Union
 
 import numpy as np
-
 from scipy.stats import norm
 
 

--- a/graspologic/pipeline/embed/adjacency_spectral_embedding.py
+++ b/graspologic/pipeline/embed/adjacency_spectral_embedding.py
@@ -1,23 +1,24 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from typing import Optional, Union
 import warnings
+from typing import Optional, Union
 
 import networkx as nx
 import numpy as np
 
-from . import __SVD_SOLVER_TYPES  # from the module init
-from ._elbow import _index_of_elbow
-from .embeddings import Embeddings
+from graspologic.embed import AdjacencySpectralEmbed
 from graspologic.preconditions import (
     check_argument,
     check_argument_types,
     check_optional_argument_types,
     is_real_weighted,
 )
-from graspologic.embed import AdjacencySpectralEmbed
 from graspologic.utils import is_fully_connected, pass_to_ranks
+
+from . import __SVD_SOLVER_TYPES  # from the module init
+from ._elbow import _index_of_elbow
+from .embeddings import Embeddings
 
 
 def adjacency_spectral_embedding(

--- a/graspologic/pipeline/embed/embeddings.py
+++ b/graspologic/pipeline/embed/embeddings.py
@@ -15,9 +15,10 @@ guarantee the appropriate latent positions are returned for each node.
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from typing import Any, Tuple
-import numpy as np
 from collections import OrderedDict
+from typing import Any, Tuple
+
+import numpy as np
 
 
 class Embeddings:

--- a/graspologic/pipeline/graph_builder.py
+++ b/graspologic/pipeline/graph_builder.py
@@ -3,7 +3,7 @@
 
 import numbers
 from collections import OrderedDict
-from typing import Any, Dict, List, Union, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 import networkx as nx
 

--- a/graspologic/plot/__init__.py
+++ b/graspologic/plot/__init__.py
@@ -2,15 +2,16 @@
 # Licensed under the MIT License.
 
 import sys
+
 import matplotlib as mpl
 
 from .plot import (
-    heatmap,
-    gridplot,
-    pairplot,
-    pairplot_with_gmm,
     degreeplot,
     edgeplot,
+    gridplot,
+    heatmap,
+    pairplot,
+    pairplot_with_gmm,
     screeplot,
 )
 from .plot_matrix import adjplot, matrixplot

--- a/graspologic/plot/plot_matrix.py
+++ b/graspologic/plot/plot_matrix.py
@@ -1,13 +1,13 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import matplotlib.pyplot as plt
-import pandas as pd
-import numpy as np
-import seaborn as sns
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
 from matplotlib.colors import ListedColormap
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 from scipy.sparse import csr_matrix
 
 

--- a/graspologic/preprocessing/__init__.py
+++ b/graspologic/preprocessing/__init__.py
@@ -3,14 +3,13 @@
 
 from .graph_cuts import (
     DefinedHistogram,
-    histogram_betweenness_centrality,
-    histogram_degree_centrality,
-    histogram_edge_weight,
     cut_edges_by_weight,
     cut_vertices_by_betweenness_centrality,
     cut_vertices_by_degree_centrality,
+    histogram_betweenness_centrality,
+    histogram_degree_centrality,
+    histogram_edge_weight,
 )
-
 
 __all__ = [
     "DefinedHistogram",

--- a/graspologic/preprocessing/graph_cuts.py
+++ b/graspologic/preprocessing/graph_cuts.py
@@ -4,9 +4,9 @@
 import logging
 import random
 from typing import Any, Callable, List, NamedTuple, Optional, Tuple, Union
+
 import networkx as nx
 import numpy as np
-
 
 LARGER_THAN_INCLUSIVE = "larger_than_inclusive"
 LARGER_THAN_EXCLUSIVE = "larger_than_exclusive"

--- a/graspologic/simulations/__init__.py
+++ b/graspologic/simulations/__init__.py
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-from .simulations import sample_edges, er_np, er_nm, sbm, rdpg, p_from_latent, mmsbm
-from .simulations_corr import sample_edges_corr, er_corr, sbm_corr
 from .rdpg_corr import rdpg_corr
+from .simulations import er_nm, er_np, mmsbm, p_from_latent, rdpg, sample_edges, sbm
+from .simulations_corr import er_corr, sample_edges_corr, sbm_corr
 
 __all__ = [
     "sample_edges",

--- a/graspologic/simulations/__init__.py
+++ b/graspologic/simulations/__init__.py
@@ -1,9 +1,10 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-from .rdpg_corr import rdpg_corr
 from .simulations import er_nm, er_np, mmsbm, p_from_latent, rdpg, sample_edges, sbm
 from .simulations_corr import er_corr, sample_edges_corr, sbm_corr
+
+from .rdpg_corr import rdpg_corr  # isort:skip
 
 __all__ = [
     "sample_edges",

--- a/graspologic/simulations/rdpg_corr.py
+++ b/graspologic/simulations/rdpg_corr.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import numpy as np
+
 from graspologic.simulations import p_from_latent, sample_edges_corr
 
 

--- a/graspologic/simulations/simulations.py
+++ b/graspologic/simulations/simulations.py
@@ -1,11 +1,12 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import numpy as np
-
-from ..utils import symmetrize, cartesian_product
-from sklearn.utils import check_array, check_scalar
 import warnings
+
+import numpy as np
+from sklearn.utils import check_array, check_scalar
+
+from ..utils import cartesian_product, symmetrize
 
 
 def _n_to_labels(n):

--- a/graspologic/simulations/simulations_corr.py
+++ b/graspologic/simulations/simulations_corr.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import numpy as np
+
 from graspologic.simulations import sample_edges
 
 

--- a/graspologic/utils/__init__.py
+++ b/graspologic/utils/__init__.py
@@ -1,29 +1,29 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
+from .ptr import pass_to_ranks
 from .utils import (
-    import_graph,
-    import_edgelist,
-    is_symmetric,
-    is_loopless,
-    is_unweighted,
-    is_almost_symmetric,
-    symmetrize,
-    remove_loops,
-    to_laplacian,
-    is_fully_connected,
-    largest_connected_component,
-    multigraph_lcc_union,
-    multigraph_lcc_intersection,
     augment_diagonal,
     binarize,
     cartesian_product,
     fit_plug_in_variance_estimator,
-    remove_vertices,
+    import_edgelist,
+    import_graph,
+    is_almost_symmetric,
+    is_fully_connected,
+    is_loopless,
+    is_symmetric,
+    is_unweighted,
+    largest_connected_component,
+    multigraph_lcc_intersection,
+    multigraph_lcc_union,
     remap_labels,
     remap_node_ids,
+    remove_loops,
+    remove_vertices,
+    symmetrize,
+    to_laplacian,
 )
-from .ptr import pass_to_ranks
 
 __all__ = [
     "import_graph",

--- a/graspologic/utils/ptr.py
+++ b/graspologic/utils/ptr.py
@@ -2,8 +2,9 @@
 # Licensed under the MIT License.
 
 import numpy as np
-from .utils import import_graph, is_unweighted, is_symmetric, is_loopless, symmetrize
 from scipy.stats import rankdata
+
+from .utils import import_graph, is_loopless, is_symmetric, is_unweighted, symmetrize
 
 
 def pass_to_ranks(graph, method="simple-nonzero"):

--- a/graspologic/version.py
+++ b/graspologic/version.py
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import datetime
-import pkg_resources
 import configparser
-
+import datetime
 from typing import Optional
+
+import pkg_resources
 
 
 def __from_distribution() -> Optional[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ dev =
      black
      ipykernel>=5.1.0
      ipython>=7.4.0
+     isort
      mypy
      nbsphinx
      numpydoc

--- a/tests/cluster/test_autogmm.py
+++ b/tests/cluster/test_autogmm.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import unittest
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from sklearn.exceptions import NotFittedError

--- a/tests/cluster/test_autogmm.py
+++ b/tests/cluster/test_autogmm.py
@@ -51,7 +51,9 @@ class TestAutoGMM(unittest.TestCase):
 
         # euclidean is not an affinity option when ward is a linkage option
         with self.assertRaises(ValueError):
-            AutoGMM = AutoGMMCluster(min_components=1, affinity="manhattan", linkage="ward")
+            AutoGMM = AutoGMMCluster(
+                min_components=1, affinity="manhattan", linkage="ward"
+            )
 
         # covariance type is not an array, string or list
         with self.assertRaises(TypeError):
@@ -121,7 +123,6 @@ class TestAutoGMM(unittest.TestCase):
         with self.assertRaises(ValueError):
             AutoGMM = AutoGMMCluster(selection_criteria="cic")
 
-
     def test_labels_init(self):
         X = np.random.normal(0, 1, size=(5, 3))
 
@@ -148,7 +149,6 @@ class TestAutoGMM(unittest.TestCase):
         )
         AutoGMM.fit_predict(X)
 
-
     def test_predict_without_fit(self):
         # Generate random data
         X = np.random.normal(0, 1, size=(100, 3))
@@ -157,14 +157,12 @@ class TestAutoGMM(unittest.TestCase):
             AutoGMM = AutoGMMCluster(min_components=2)
             AutoGMM.predict(X)
 
-
     def test_cosine_on_0(self):
         X = np.array([[0, 1, 0], [1, 0, 1], [0, 0, 0], [1, 1, 0], [0, 0, 1]])
 
         with self.assertRaises(ValueError):
             AutoGMM = AutoGMMCluster(min_components=3, affinity="all")
             AutoGMM.fit(X)
-
 
     def test_cosine_with_0(self):
         X = np.array(
@@ -187,7 +185,6 @@ class TestAutoGMM(unittest.TestCase):
             AutoGMM = AutoGMMCluster(min_components=2, affinity="all")
             AutoGMM.fit(X)
 
-
     def test_no_y(self):
         np.random.seed(1)
 
@@ -202,7 +199,6 @@ class TestAutoGMM(unittest.TestCase):
         AutoGMM.fit(X)
 
         assert_equal(AutoGMM.n_components_, 2)
-
 
     def test_two_class(self):
         """
@@ -229,7 +225,6 @@ class TestAutoGMM(unittest.TestCase):
         # Asser that we get perfect clustering
         assert_allclose(AutoGMM.ari_, 1)
 
-
     def test_two_class_parallel(self):
         """
         Easily separable two gaussian problem.
@@ -254,7 +249,6 @@ class TestAutoGMM(unittest.TestCase):
 
         # Asser that we get perfect clustering
         assert_allclose(AutoGMM.ari_, 1)
-
 
     def test_two_class_aic(self):
         """
@@ -283,7 +277,6 @@ class TestAutoGMM(unittest.TestCase):
         assert_equal(AutoGMM.ari_ >= -1, True)
         assert_equal(AutoGMM.ari_ <= 1, True)
 
-
     def test_five_class(self):
         """
         Easily separable five gaussian problem.
@@ -296,11 +289,12 @@ class TestAutoGMM(unittest.TestCase):
 
         X = np.vstack([np.random.multivariate_normal(mu, cov, n) for mu in mus])
 
-        AutoGMM = AutoGMMCluster(min_components=3, max_components=10, covariance_type="all")
+        AutoGMM = AutoGMMCluster(
+            min_components=3, max_components=10, covariance_type="all"
+        )
         AutoGMM.fit(X)
 
         assert_equal(AutoGMM.n_components_, 5)
-
 
     def test_five_class_aic(self):
         """
@@ -325,7 +319,6 @@ class TestAutoGMM(unittest.TestCase):
         # AIC fails often so there is no assertion here
         assert_equal(AutoGMM.n_components_ >= 3, True)
         assert_equal(AutoGMM.n_components_ <= 10, True)
-
 
     def test_ase_three_blocks(self):
         """
@@ -356,7 +349,6 @@ class TestAutoGMM(unittest.TestCase):
 
         # Asser that we get perfect clustering
         assert_allclose(AutoGMM.ari_, 1)
-
 
     def test_covariances(self):
         """

--- a/tests/cluster/test_autogmm.py
+++ b/tests/cluster/test_autogmm.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import pytest
+import unittest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from sklearn.exceptions import NotFittedError
@@ -11,410 +11,411 @@ from graspologic.embed.ase import AdjacencySpectralEmbed
 from graspologic.simulations.simulations import sbm
 
 
-def test_inputs():
-    # Generate random data
-    X = np.random.normal(0, 1, size=(100, 3))
+class TestAutoGMM(unittest.TestCase):
+    def test_inputs(self):
+        # Generate random data
+        X = np.random.normal(0, 1, size=(100, 3))
 
-    # min_components < 1
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(min_components=0)
+        # min_components < 1
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(min_components=0)
 
-    # min_components integer
-    with pytest.raises(TypeError):
-        AutoGMM = AutoGMMCluster(min_components="1")
+        # min_components integer
+        with self.assertRaises(TypeError):
+            AutoGMM = AutoGMMCluster(min_components="1")
 
-    # max_components < min_components
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(min_components=1, max_components=0)
+        # max_components < min_components
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(min_components=1, max_components=0)
 
-    # max_components integer
-    with pytest.raises(TypeError):
-        AutoGMM = AutoGMMCluster(min_components=1, max_components="1")
+        # max_components integer
+        with self.assertRaises(TypeError):
+            AutoGMM = AutoGMMCluster(min_components=1, max_components="1")
 
-    # affinity is not an array, string or list
-    with pytest.raises(TypeError):
-        AutoGMM = AutoGMMCluster(min_components=1, affinity=1)
+        # affinity is not an array, string or list
+        with self.assertRaises(TypeError):
+            AutoGMM = AutoGMMCluster(min_components=1, affinity=1)
 
-    # affinity is not in ['euclidean', 'manhattan', 'cosine', 'none']
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(min_components=1, affinity="graspologic")
+        # affinity is not in ['euclidean', 'manhattan', 'cosine', 'none']
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(min_components=1, affinity="graspologic")
 
-    # linkage is not an array, string or list
-    with pytest.raises(TypeError):
-        AutoGMM = AutoGMMCluster(min_components=1, linkage=1)
+        # linkage is not an array, string or list
+        with self.assertRaises(TypeError):
+            AutoGMM = AutoGMMCluster(min_components=1, linkage=1)
 
-    # linkage is not in ['single', 'average', 'complete', 'ward']
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(min_components=1, linkage="graspologic")
+        # linkage is not in ['single', 'average', 'complete', 'ward']
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(min_components=1, linkage="graspologic")
 
-    # euclidean is not an affinity option when ward is a linkage option
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(min_components=1, affinity="manhattan", linkage="ward")
+        # euclidean is not an affinity option when ward is a linkage option
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(min_components=1, affinity="manhattan", linkage="ward")
 
-    # covariance type is not an array, string or list
-    with pytest.raises(TypeError):
-        AutoGMM = AutoGMMCluster(min_components=1, covariance_type=1)
+        # covariance type is not an array, string or list
+        with self.assertRaises(TypeError):
+            AutoGMM = AutoGMMCluster(min_components=1, covariance_type=1)
 
-    # covariance type is not in ['spherical', 'diag', 'tied', 'full']
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(min_components=1, covariance_type="graspologic")
+        # covariance type is not in ['spherical', 'diag', 'tied', 'full']
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(min_components=1, covariance_type="graspologic")
 
-    # min_cluster > n_samples when max_cluster is None
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(1000)
-        AutoGMM.fit(X)
+        # min_cluster > n_samples when max_cluster is None
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(1000)
+            AutoGMM.fit(X)
 
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(1000)
-        AutoGMM.fit_predict(X)
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(1000)
+            AutoGMM.fit_predict(X)
 
-    # max_cluster > n_samples when max_cluster is not None
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(10, 1001)
-        AutoGMM.fit(X)
+        # max_cluster > n_samples when max_cluster is not None
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(10, 1001)
+            AutoGMM.fit(X)
 
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(10, 1001)
-        AutoGMM.fit_predict(X)
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(10, 1001)
+            AutoGMM.fit_predict(X)
 
-    # min_cluster > n_samples when max_cluster is None
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(1000)
-        AutoGMM.fit(X)
+        # min_cluster > n_samples when max_cluster is None
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(1000)
+            AutoGMM.fit(X)
 
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(10, 1001)
-        AutoGMM.fit_predict(X)
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(10, 1001)
+            AutoGMM.fit_predict(X)
 
-    # min_cluster > n_samples when max_cluster is not None
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(1000, 1001)
-        AutoGMM.fit(X)
+        # min_cluster > n_samples when max_cluster is not None
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(1000, 1001)
+            AutoGMM.fit(X)
 
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(1000, 1001)
-        AutoGMM.fit_predict(X)
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(1000, 1001)
+            AutoGMM.fit_predict(X)
 
-    # label_init is not a 1-D array
-    with pytest.raises(TypeError):
-        AutoGMM = AutoGMMCluster(label_init=np.zeros([100, 2]))
+        # label_init is not a 1-D array
+        with self.assertRaises(TypeError):
+            AutoGMM = AutoGMMCluster(label_init=np.zeros([100, 2]))
 
-    # label_init is not 1-D array, a list or None.
-    with pytest.raises(TypeError):
-        AutoGMM = AutoGMMCluster(label_init="label")
+        # label_init is not 1-D array, a list or None.
+        with self.assertRaises(TypeError):
+            AutoGMM = AutoGMMCluster(label_init="label")
 
-    # label_init length is not equal to n_samples
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(label_init=np.zeros([50, 1]))
-        AutoGMM.fit(X)
+        # label_init length is not equal to n_samples
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(label_init=np.zeros([50, 1]))
+            AutoGMM.fit(X)
 
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(label_init=np.zeros([50, 1]))
-        AutoGMM.fit_predict(X)
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(label_init=np.zeros([50, 1]))
+            AutoGMM.fit_predict(X)
 
-    with pytest.raises(TypeError):
-        AutoGMM = AutoGMMCluster(label_init=np.zeros([100, 2]), max_iter=-2)
+        with self.assertRaises(TypeError):
+            AutoGMM = AutoGMMCluster(label_init=np.zeros([100, 2]), max_iter=-2)
 
-    # criter = cic
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(selection_criteria="cic")
+        # criter = cic
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(selection_criteria="cic")
 
 
-def test_labels_init():
-    X = np.random.normal(0, 1, size=(5, 3))
+    def test_labels_init(self):
+        X = np.random.normal(0, 1, size=(5, 3))
 
-    with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(
+                min_components=1, max_components=1, label_init=np.array([0, 0, 0, 0, 1])
+            )
+            AutoGMM.fit_predict(X)
+
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(
+                min_components=1, max_components=2, label_init=np.array([0, 0, 0, 0, 1])
+            )
+            AutoGMM.fit_predict(X)
+
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(
+                min_components=2, max_components=3, label_init=np.array([0, 0, 0, 0, 1])
+            )
+            AutoGMM.fit_predict(X)
+
         AutoGMM = AutoGMMCluster(
-            min_components=1, max_components=1, label_init=np.array([0, 0, 0, 0, 1])
+            min_components=2, max_components=2, label_init=np.array([0, 0, 0, 0, 1])
         )
         AutoGMM.fit_predict(X)
 
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(
-            min_components=1, max_components=2, label_init=np.array([0, 0, 0, 0, 1])
+
+    def test_predict_without_fit(self):
+        # Generate random data
+        X = np.random.normal(0, 1, size=(100, 3))
+
+        with self.assertRaises(NotFittedError):
+            AutoGMM = AutoGMMCluster(min_components=2)
+            AutoGMM.predict(X)
+
+
+    def test_cosine_on_0(self):
+        X = np.array([[0, 1, 0], [1, 0, 1], [0, 0, 0], [1, 1, 0], [0, 0, 1]])
+
+        with self.assertRaises(ValueError):
+            AutoGMM = AutoGMMCluster(min_components=3, affinity="all")
+            AutoGMM.fit(X)
+
+
+    def test_cosine_with_0(self):
+        X = np.array(
+            [
+                [0, 1, 0],
+                [1, 0, 1],
+                [0, 0, 0],
+                [1, 1, 0],
+                [0, 0, 1],
+                [0, 1, 1],
+                [1, 1, 1],
+                [1, 0, 0],
+                [0, 1, 1],
+                [1, 1, 0],
+                [0, 1, 0],
+            ]
         )
-        AutoGMM.fit_predict(X)
 
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(
-            min_components=2, max_components=3, label_init=np.array([0, 0, 0, 0, 1])
-        )
-        AutoGMM.fit_predict(X)
-
-    AutoGMM = AutoGMMCluster(
-        min_components=2, max_components=2, label_init=np.array([0, 0, 0, 0, 1])
-    )
-    AutoGMM.fit_predict(X)
+        with self.assertWarns(UserWarning):
+            AutoGMM = AutoGMMCluster(min_components=2, affinity="all")
+            AutoGMM.fit(X)
 
 
-def test_predict_without_fit():
-    # Generate random data
-    X = np.random.normal(0, 1, size=(100, 3))
+    def test_no_y(self):
+        np.random.seed(1)
 
-    with pytest.raises(NotFittedError):
-        AutoGMM = AutoGMMCluster(min_components=2)
-        AutoGMM.predict(X)
+        n = 100
+        d = 3
 
+        X1 = np.random.normal(2, 0.5, size=(n, d))
+        X2 = np.random.normal(-2, 0.5, size=(n, d))
+        X = np.vstack((X1, X2))
 
-def test_cosine_on_0():
-    X = np.array([[0, 1, 0], [1, 0, 1], [0, 0, 0], [1, 1, 0], [0, 0, 1]])
-
-    with pytest.raises(ValueError):
-        AutoGMM = AutoGMMCluster(min_components=3, affinity="all")
+        AutoGMM = AutoGMMCluster(max_components=5)
         AutoGMM.fit(X)
 
+        assert_equal(AutoGMM.n_components_, 2)
 
-def test_cosine_with_0():
-    X = np.array(
-        [
-            [0, 1, 0],
-            [1, 0, 1],
-            [0, 0, 0],
-            [1, 1, 0],
-            [0, 0, 1],
-            [0, 1, 1],
-            [1, 1, 1],
-            [1, 0, 0],
-            [0, 1, 1],
-            [1, 1, 0],
-            [0, 1, 0],
-        ]
-    )
 
-    with pytest.warns(UserWarning):
-        AutoGMM = AutoGMMCluster(min_components=2, affinity="all")
+    def test_two_class(self):
+        """
+        Easily separable two gaussian problem.
+        """
+        np.random.seed(1)
+
+        n = 100
+        d = 3
+
+        X1 = np.random.normal(2, 0.5, size=(n, d))
+        X2 = np.random.normal(-2, 0.5, size=(n, d))
+        X = np.vstack((X1, X2))
+        y = np.repeat([0, 1], n)
+
+        AutoGMM = AutoGMMCluster(max_components=5)
+        AutoGMM.fit(X, y)
+
+        n_components = AutoGMM.n_components_
+
+        # Assert that the two cluster model is the best
+        assert_equal(n_components, 2)
+
+        # Asser that we get perfect clustering
+        assert_allclose(AutoGMM.ari_, 1)
+
+
+    def test_two_class_parallel(self):
+        """
+        Easily separable two gaussian problem.
+        """
+        np.random.seed(1)
+
+        n = 100
+        d = 3
+
+        X1 = np.random.normal(2, 0.5, size=(n, d))
+        X2 = np.random.normal(-2, 0.5, size=(n, d))
+        X = np.vstack((X1, X2))
+        y = np.repeat([0, 1], n)
+
+        AutoGMM = AutoGMMCluster(max_components=5, n_jobs=2)
+        AutoGMM.fit(X, y)
+
+        n_components = AutoGMM.n_components_
+
+        # Assert that the two cluster model is the best
+        assert_equal(n_components, 2)
+
+        # Asser that we get perfect clustering
+        assert_allclose(AutoGMM.ari_, 1)
+
+
+    def test_two_class_aic(self):
+        """
+        Easily separable two gaussian problem.
+        """
+        np.random.seed(1)
+
+        n = 100
+        d = 3
+
+        X1 = np.random.normal(2, 0.5, size=(n, d))
+        X2 = np.random.normal(-2, 0.5, size=(n, d))
+        X = np.vstack((X1, X2))
+        y = np.repeat([0, 1], n)
+
+        AutoGMM = AutoGMMCluster(max_components=5, selection_criteria="aic")
+        AutoGMM.fit(X, y)
+
+        n_components = AutoGMM.n_components_
+
+        # AIC gets the number of components wrong
+        assert_equal(n_components >= 1, True)
+        assert_equal(n_components <= 5, True)
+
+        # Assert that the ari value is valid
+        assert_equal(AutoGMM.ari_ >= -1, True)
+        assert_equal(AutoGMM.ari_ <= 1, True)
+
+
+    def test_five_class(self):
+        """
+        Easily separable five gaussian problem.
+        """
+        np.random.seed(1)
+
+        n = 100
+        mus = [[i * 5, 0] for i in range(5)]
+        cov = np.eye(2)  # balls
+
+        X = np.vstack([np.random.multivariate_normal(mu, cov, n) for mu in mus])
+
+        AutoGMM = AutoGMMCluster(min_components=3, max_components=10, covariance_type="all")
         AutoGMM.fit(X)
 
+        assert_equal(AutoGMM.n_components_, 5)
 
-def test_no_y():
-    np.random.seed(1)
 
-    n = 100
-    d = 3
+    def test_five_class_aic(self):
+        """
+        Easily separable five gaussian problem.
+        """
+        np.random.seed(1)
 
-    X1 = np.random.normal(2, 0.5, size=(n, d))
-    X2 = np.random.normal(-2, 0.5, size=(n, d))
-    X = np.vstack((X1, X2))
+        n = 100
+        mus = [[i * 5, 0] for i in range(5)]
+        cov = np.eye(2)  # balls
 
-    AutoGMM = AutoGMMCluster(max_components=5)
-    AutoGMM.fit(X)
+        X = np.vstack([np.random.multivariate_normal(mu, cov, n) for mu in mus])
 
-    assert_equal(AutoGMM.n_components_, 2)
+        AutoGMM = AutoGMMCluster(
+            min_components=3,
+            max_components=10,
+            covariance_type="all",
+            selection_criteria="aic",
+        )
+        AutoGMM.fit(X)
 
+        # AIC fails often so there is no assertion here
+        assert_equal(AutoGMM.n_components_ >= 3, True)
+        assert_equal(AutoGMM.n_components_ <= 10, True)
 
-def test_two_class():
-    """
-    Easily separable two gaussian problem.
-    """
-    np.random.seed(1)
 
-    n = 100
-    d = 3
+    def test_ase_three_blocks(self):
+        """
+        Expect 3 clusters from a 3 block model
+        """
+        np.random.seed(1)
 
-    X1 = np.random.normal(2, 0.5, size=(n, d))
-    X2 = np.random.normal(-2, 0.5, size=(n, d))
-    X = np.vstack((X1, X2))
-    y = np.repeat([0, 1], n)
+        # Generate adjacency and labels
+        n = 50
+        n_communites = [n, n, n]
+        p = np.array([[0.8, 0.3, 0.2], [0.3, 0.8, 0.3], [0.2, 0.3, 0.8]])
+        y = np.repeat([1, 2, 3], repeats=n)
 
-    AutoGMM = AutoGMMCluster(max_components=5)
-    AutoGMM.fit(X, y)
+        A = sbm(n=n_communites, p=p)
 
-    n_components = AutoGMM.n_components_
+        # Embed to get latent positions
+        ase = AdjacencySpectralEmbed(n_components=5)
+        X_hat = ase.fit_transform(A)
 
-    # Assert that the two cluster model is the best
-    assert_equal(n_components, 2)
+        # Compute clusters
+        AutoGMM = AutoGMMCluster(max_components=10)
+        AutoGMM.fit(X_hat, y)
 
-    # Asser that we get perfect clustering
-    assert_allclose(AutoGMM.ari_, 1)
+        n_components = AutoGMM.n_components_
 
+        # Assert that the three cluster model is the best
+        assert_equal(n_components, 3)
 
-def test_two_class_parallel():
-    """
-    Easily separable two gaussian problem.
-    """
-    np.random.seed(1)
+        # Asser that we get perfect clustering
+        assert_allclose(AutoGMM.ari_, 1)
 
-    n = 100
-    d = 3
 
-    X1 = np.random.normal(2, 0.5, size=(n, d))
-    X2 = np.random.normal(-2, 0.5, size=(n, d))
-    X = np.vstack((X1, X2))
-    y = np.repeat([0, 1], n)
+    def test_covariances(self):
+        """
+        Easily separable two gaussian problem.
+        """
+        np.random.seed(1)
 
-    AutoGMM = AutoGMMCluster(max_components=5, n_jobs=2)
-    AutoGMM.fit(X, y)
+        n = 100
+        mu1 = [-10, 0]
+        mu2 = [10, 0]
 
-    n_components = AutoGMM.n_components_
+        # Spherical
+        cov1 = 2 * np.eye(2)
+        cov2 = 2 * np.eye(2)
 
-    # Assert that the two cluster model is the best
-    assert_equal(n_components, 2)
+        X1 = np.random.multivariate_normal(mu1, cov1, n)
+        X2 = np.random.multivariate_normal(mu2, cov2, n)
 
-    # Asser that we get perfect clustering
-    assert_allclose(AutoGMM.ari_, 1)
+        X = np.concatenate((X1, X2))
 
+        AutoGMM = AutoGMMCluster(min_components=2, covariance_type="all")
+        AutoGMM.fit(X)
+        assert_equal(AutoGMM.covariance_type_, "spherical")
 
-def test_two_class_aic():
-    """
-    Easily separable two gaussian problem.
-    """
-    np.random.seed(1)
+        # Diagonal
+        np.random.seed(10)
+        cov1 = np.diag([1, 1])
+        cov2 = np.diag([2, 1])
 
-    n = 100
-    d = 3
+        X1 = np.random.multivariate_normal(mu1, cov1, n)
+        X2 = np.random.multivariate_normal(mu2, cov2, n)
 
-    X1 = np.random.normal(2, 0.5, size=(n, d))
-    X2 = np.random.normal(-2, 0.5, size=(n, d))
-    X = np.vstack((X1, X2))
-    y = np.repeat([0, 1], n)
+        X = np.concatenate((X1, X2))
 
-    AutoGMM = AutoGMMCluster(max_components=5, selection_criteria="aic")
-    AutoGMM.fit(X, y)
+        AutoGMM = AutoGMMCluster(max_components=2, covariance_type="all")
+        AutoGMM.fit(X)
+        assert_equal(AutoGMM.covariance_type_, "diag")
 
-    n_components = AutoGMM.n_components_
+        # Tied
+        cov1 = np.array([[2, 1], [1, 2]])
+        cov2 = np.array([[2, 1], [1, 2]])
 
-    # AIC gets the number of components wrong
-    assert_equal(n_components >= 1, True)
-    assert_equal(n_components <= 5, True)
+        X1 = np.random.multivariate_normal(mu1, cov1, n)
+        X2 = np.random.multivariate_normal(mu2, cov2, n)
 
-    # Assert that the ari value is valid
-    assert_equal(AutoGMM.ari_ >= -1, True)
-    assert_equal(AutoGMM.ari_ <= 1, True)
+        X = np.concatenate((X1, X2))
 
+        AutoGMM = AutoGMMCluster(max_components=2, covariance_type="all")
+        AutoGMM.fit(X)
+        assert_equal(AutoGMM.covariance_type_, "tied")
 
-def test_five_class():
-    """
-    Easily separable five gaussian problem.
-    """
-    np.random.seed(1)
+        # Full
+        cov1 = np.array([[2, -1], [-1, 2]])
+        cov2 = np.array([[2, 1], [1, 2]])
 
-    n = 100
-    mus = [[i * 5, 0] for i in range(5)]
-    cov = np.eye(2)  # balls
+        X1 = np.random.multivariate_normal(mu1, cov1, n)
+        X2 = np.random.multivariate_normal(mu2, cov2, n)
 
-    X = np.vstack([np.random.multivariate_normal(mu, cov, n) for mu in mus])
+        X = np.concatenate((X1, X2))
 
-    AutoGMM = AutoGMMCluster(min_components=3, max_components=10, covariance_type="all")
-    AutoGMM.fit(X)
-
-    assert_equal(AutoGMM.n_components_, 5)
-
-
-def test_five_class_aic():
-    """
-    Easily separable five gaussian problem.
-    """
-    np.random.seed(1)
-
-    n = 100
-    mus = [[i * 5, 0] for i in range(5)]
-    cov = np.eye(2)  # balls
-
-    X = np.vstack([np.random.multivariate_normal(mu, cov, n) for mu in mus])
-
-    AutoGMM = AutoGMMCluster(
-        min_components=3,
-        max_components=10,
-        covariance_type="all",
-        selection_criteria="aic",
-    )
-    AutoGMM.fit(X)
-
-    # AIC fails often so there is no assertion here
-    assert_equal(AutoGMM.n_components_ >= 3, True)
-    assert_equal(AutoGMM.n_components_ <= 10, True)
-
-
-def test_ase_three_blocks():
-    """
-    Expect 3 clusters from a 3 block model
-    """
-    np.random.seed(1)
-
-    # Generate adjacency and labels
-    n = 50
-    n_communites = [n, n, n]
-    p = np.array([[0.8, 0.3, 0.2], [0.3, 0.8, 0.3], [0.2, 0.3, 0.8]])
-    y = np.repeat([1, 2, 3], repeats=n)
-
-    A = sbm(n=n_communites, p=p)
-
-    # Embed to get latent positions
-    ase = AdjacencySpectralEmbed(n_components=5)
-    X_hat = ase.fit_transform(A)
-
-    # Compute clusters
-    AutoGMM = AutoGMMCluster(max_components=10)
-    AutoGMM.fit(X_hat, y)
-
-    n_components = AutoGMM.n_components_
-
-    # Assert that the three cluster model is the best
-    assert_equal(n_components, 3)
-
-    # Asser that we get perfect clustering
-    assert_allclose(AutoGMM.ari_, 1)
-
-
-def test_covariances():
-    """
-    Easily separable two gaussian problem.
-    """
-    np.random.seed(1)
-
-    n = 100
-    mu1 = [-10, 0]
-    mu2 = [10, 0]
-
-    # Spherical
-    cov1 = 2 * np.eye(2)
-    cov2 = 2 * np.eye(2)
-
-    X1 = np.random.multivariate_normal(mu1, cov1, n)
-    X2 = np.random.multivariate_normal(mu2, cov2, n)
-
-    X = np.concatenate((X1, X2))
-
-    AutoGMM = AutoGMMCluster(min_components=2, covariance_type="all")
-    AutoGMM.fit(X)
-    assert_equal(AutoGMM.covariance_type_, "spherical")
-
-    # Diagonal
-    np.random.seed(10)
-    cov1 = np.diag([1, 1])
-    cov2 = np.diag([2, 1])
-
-    X1 = np.random.multivariate_normal(mu1, cov1, n)
-    X2 = np.random.multivariate_normal(mu2, cov2, n)
-
-    X = np.concatenate((X1, X2))
-
-    AutoGMM = AutoGMMCluster(max_components=2, covariance_type="all")
-    AutoGMM.fit(X)
-    assert_equal(AutoGMM.covariance_type_, "diag")
-
-    # Tied
-    cov1 = np.array([[2, 1], [1, 2]])
-    cov2 = np.array([[2, 1], [1, 2]])
-
-    X1 = np.random.multivariate_normal(mu1, cov1, n)
-    X2 = np.random.multivariate_normal(mu2, cov2, n)
-
-    X = np.concatenate((X1, X2))
-
-    AutoGMM = AutoGMMCluster(max_components=2, covariance_type="all")
-    AutoGMM.fit(X)
-    assert_equal(AutoGMM.covariance_type_, "tied")
-
-    # Full
-    cov1 = np.array([[2, -1], [-1, 2]])
-    cov2 = np.array([[2, 1], [1, 2]])
-
-    X1 = np.random.multivariate_normal(mu1, cov1, n)
-    X2 = np.random.multivariate_normal(mu2, cov2, n)
-
-    X = np.concatenate((X1, X2))
-
-    AutoGMM = AutoGMMCluster(max_components=2, covariance_type="all")
-    AutoGMM.fit(X)
-    assert_equal(AutoGMM.covariance_type_, "full")
+        AutoGMM = AutoGMMCluster(max_components=2, covariance_type="all")
+        AutoGMM.fit(X)
+        assert_equal(AutoGMM.covariance_type_, "full")

--- a/tests/cluster/test_divisive_cluster.py
+++ b/tests/cluster/test_divisive_cluster.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import numpy as np
 import unittest
+
+import numpy as np
 from numpy.testing import assert_allclose, assert_array_less, assert_equal
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import adjusted_rand_score

--- a/tests/cluster/test_divisive_cluster.py
+++ b/tests/cluster/test_divisive_cluster.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import numpy as np
-import pytest
+import unittest
 from numpy.testing import assert_allclose, assert_array_less, assert_equal
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import adjusted_rand_score
@@ -10,197 +10,26 @@ from sklearn.metrics import adjusted_rand_score
 from graspologic.cluster import DivisiveCluster
 
 
-def test_inputs():
-    # Generate random data
-    X = np.random.normal(0, 1, size=(100, 3))
-
-    # min_components < 1
-    with pytest.raises(ValueError):
-        dc = DivisiveCluster(min_components=0)
-
-    # min_components not integer
-    with pytest.raises(TypeError):
-        dc = DivisiveCluster(min_components="1")
-
-    # max_components < min_components
-    with pytest.raises(ValueError):
-        dc = DivisiveCluster(min_components=1, max_components=0)
-
-    # max_components not integer
-    with pytest.raises(TypeError):
-        dc = DivisiveCluster(max_components="1")
-
-    # cluster_method not in ['gmm', 'kmeans']
-    with pytest.raises(ValueError):
-        dc = DivisiveCluster(cluster_method="graspologic")
-
-    # delta_criter negative
-    with pytest.raises(ValueError):
-        dc = DivisiveCluster(delta_criter=-1)
-
-    # cluster_kws not a dict
-    with pytest.raises(TypeError):
-        dc = DivisiveCluster(cluster_kws=0)
-
-    # max_components > n_sample
-    with pytest.raises(ValueError):
-        dc = DivisiveCluster(max_components=101)
-        dc.fit(X)
-
-    # level not an int
-    with pytest.raises(TypeError):
-        rc = DivisiveCluster(max_components=2)
-        rc.fit_predict(X, fcluster=True, level="1")
-
-    with pytest.raises(TypeError):
-        rc = DivisiveCluster(max_components=2)
-        rc.fit(X)
-        rc.predict(X, fcluster=True, level="1")
-
-    # level not positive
-    with pytest.raises(ValueError):
-        rc = DivisiveCluster(max_components=2)
-        rc.fit_predict(X, fcluster=True, level=0)
-
-    with pytest.raises(ValueError):
-        rc = DivisiveCluster(max_components=2)
-        rc.fit(X)
-        rc.predict(X, fcluster=True, level=0)
-
-    # level exceeds n_level
-    with pytest.raises(ValueError):
-        dc = DivisiveCluster(max_components=2)
-        dc.fit_predict(X, fcluster=True, level=100)
-
-    with pytest.raises(ValueError):
-        dc = DivisiveCluster(max_components=2)
-        dc.fit(X)
-        dc.predict(X, fcluster=True, level=100)
-
-    # level is given but fcluster disabled
-    with pytest.raises(ValueError):
-        dc = DivisiveCluster(max_components=2)
-        dc.fit_predict(X, level=1)
-
-    with pytest.raises(ValueError):
-        dc = DivisiveCluster(max_components=2)
-        dc.fit(X)
-        dc.predict(X, level=1)
-
-
-def test_predict_without_fit():
-    # Generate random data
-    X = np.random.normal(0, 1, size=(100, 3))
-
-    with pytest.raises(NotFittedError):
-        dc = DivisiveCluster(max_components=2)
-        dc.predict(X)
-
-
-def test_predict_on_nonfitted_data_gmm():
-    # Generate random data to fit on
-    np.random.seed(1)
-    n = 100
-    d = 3
-    X1 = np.random.normal(1, 0.1, size=(n, d))
-    X2 = np.random.normal(2, 0.1, size=(n, d))
-    X = np.vstack((X1, X2))
-    y = np.repeat([0, 1], n)
-
-    dc = DivisiveCluster(max_components=2)
-    pred1 = dc.fit_predict(X)
-
-    # Generate random data to predict on
-    np.random.seed(2)
-    n = 50
-    d = 3
-    X1_new = np.random.normal(1, 0.1, size=(n, d))
-    X2_new = np.random.normal(2, 0.1, size=(n, d))
-    X_new = np.vstack((X1_new, X2_new))
-    y_new = np.repeat([0, 1], n)
-
-    pred2 = dc.predict(X_new)
-
-    # Assert that both predictions have the same depth
-    assert_equal(pred1.shape[1], pred2.shape[1])
-
-    # Assert that both predictions represent a perfect clustering
-    # of 2 clusters
-    assert_equal(np.max(pred1) + 1, 2)
-    ari_1 = adjusted_rand_score(y, pred1[:, 0])
-    assert_allclose(ari_1, 1)
-
-    assert_equal(np.max(pred2) + 1, 2)
-    ari_2 = adjusted_rand_score(y_new, pred2[:, 0])
-    assert_allclose(ari_2, 1)
-
-
-def test_predict_on_nonfitted_data_kmeans():
-    # Generate random data to fit on
-    np.random.seed(1)
-    n = 100
-    d = 3
-    X1 = np.random.normal(1, 0.1, size=(n, d))
-    X2 = np.random.normal(2, 0.1, size=(n, d))
-    X = np.vstack((X1, X2))
-    y = np.repeat([0, 1], n)
-
-    dc = DivisiveCluster(max_components=2, cluster_method="kmeans")
-    pred1 = dc.fit_predict(X)
-
-    # Generate random data to predict on
-    np.random.seed(2)
-    n = 50
-    d = 3
-    X1_new = np.random.normal(1, 0.1, size=(n, d))
-    X2_new = np.random.normal(2, 0.1, size=(n, d))
-    X_new = np.vstack((X1_new, X2_new))
-    y_new = np.repeat([0, 1], n)
-
-    pred2 = dc.predict(X_new)
-
-    # Assert that both predictions have the same depth
-    assert_equal(pred1.shape[1], pred2.shape[1])
-
-    # Assert that both predictions represent a perfect clustering
-    # of 2 clusters at 1st level
-    assert_equal(np.max(pred1[:, 0]) + 1, 2)
-    ari_1 = adjusted_rand_score(y, pred1[:, 0])
-    assert_allclose(ari_1, 1)
-
-    assert_equal(np.max(pred2[:, 0]) + 1, 2)
-    ari_2 = adjusted_rand_score(y_new, pred2[:, 0])
-    assert_allclose(ari_2, 1)
-
-    # Assert that predictions on new data have the same or fewer
-    # clusters than those on the fitted data at each level
-    for lvl in range(pred1.shape[1]):
-        n_cluster1 = np.max(pred1[:, lvl]) + 1
-        n_cluster2 = np.max(pred2[:, lvl]) + 1
-        assert_array_less(n_cluster2, n_cluster1 + 1)
-
-
-#  Easily separable hierarchical data with 2 levels
-#  of four gaussians
-np.random.seed(1)
-n = 100
-d = 3
-
-X11 = np.random.normal(-5, 0.1, size=(n, d))
-X21 = np.random.normal(-2, 0.1, size=(n, d))
-X12 = np.random.normal(2, 0.1, size=(n, d))
-X22 = np.random.normal(5, 0.1, size=(n, d))
-X = np.vstack((X11, X21, X12, X22))
-
-# true labels of 2 levels
-y_lvl1 = np.repeat([0, 1], 2 * n)
-y_lvl2 = np.repeat([0, 1, 2, 3], n)
-
-
 def _test_hierarchical_four_class(**kws):
     """
     Clustering above hierarchical data with gmm
     """
+    #  Easily separable hierarchical data with 2 levels
+    #  of four gaussians
+    np.random.seed(1)
+    n = 100
+    d = 3
+
+    X11 = np.random.normal(-5, 0.1, size=(n, d))
+    X21 = np.random.normal(-2, 0.1, size=(n, d))
+    X12 = np.random.normal(2, 0.1, size=(n, d))
+    X22 = np.random.normal(5, 0.1, size=(n, d))
+    X = np.vstack((X11, X21, X12, X22))
+
+    # true labels of 2 levels
+    y_lvl1 = np.repeat([0, 1], 2 * n)
+    y_lvl2 = np.repeat([0, 1, 2, 3], n)
+
     np.random.seed(1)
     dc = DivisiveCluster(max_components=2, **kws)
     pred = dc.fit_predict(X, fcluster=True)
@@ -219,66 +48,237 @@ def _test_hierarchical_four_class(**kws):
     assert_allclose(ari_lvl2, 1)
 
 
-def test_hierarchical_four_class_gmm():
-    _test_hierarchical_four_class(cluster_method="gmm")
+class TestDivisiveCluster(unittest.TestCase):
+    def test_inputs(self):
+        # Generate random data
+        X = np.random.normal(0, 1, size=(100, 3))
+
+        # min_components < 1
+        with self.assertRaises(ValueError):
+            dc = DivisiveCluster(min_components=0)
+
+        # min_components not integer
+        with self.assertRaises(TypeError):
+            dc = DivisiveCluster(min_components="1")
+
+        # max_components < min_components
+        with self.assertRaises(ValueError):
+            dc = DivisiveCluster(min_components=1, max_components=0)
+
+        # max_components not integer
+        with self.assertRaises(TypeError):
+            dc = DivisiveCluster(max_components="1")
+
+        # cluster_method not in ['gmm', 'kmeans']
+        with self.assertRaises(ValueError):
+            dc = DivisiveCluster(cluster_method="graspologic")
+
+        # delta_criter negative
+        with self.assertRaises(ValueError):
+            dc = DivisiveCluster(delta_criter=-1)
+
+        # cluster_kws not a dict
+        with self.assertRaises(TypeError):
+            dc = DivisiveCluster(cluster_kws=0)
+
+        # max_components > n_sample
+        with self.assertRaises(ValueError):
+            dc = DivisiveCluster(max_components=101)
+            dc.fit(X)
+
+        # level not an int
+        with self.assertRaises(TypeError):
+            rc = DivisiveCluster(max_components=2)
+            rc.fit_predict(X, fcluster=True, level="1")
+
+        with self.assertRaises(TypeError):
+            rc = DivisiveCluster(max_components=2)
+            rc.fit(X)
+            rc.predict(X, fcluster=True, level="1")
+
+        # level not positive
+        with self.assertRaises(ValueError):
+            rc = DivisiveCluster(max_components=2)
+            rc.fit_predict(X, fcluster=True, level=0)
+
+        with self.assertRaises(ValueError):
+            rc = DivisiveCluster(max_components=2)
+            rc.fit(X)
+            rc.predict(X, fcluster=True, level=0)
+
+        # level exceeds n_level
+        with self.assertRaises(ValueError):
+            dc = DivisiveCluster(max_components=2)
+            dc.fit_predict(X, fcluster=True, level=100)
+
+        with self.assertRaises(ValueError):
+            dc = DivisiveCluster(max_components=2)
+            dc.fit(X)
+            dc.predict(X, fcluster=True, level=100)
+
+        # level is given but fcluster disabled
+        with self.assertRaises(ValueError):
+            dc = DivisiveCluster(max_components=2)
+            dc.fit_predict(X, level=1)
+
+        with self.assertRaises(ValueError):
+            dc = DivisiveCluster(max_components=2)
+            dc.fit(X)
+            dc.predict(X, level=1)
 
 
-def test_hierarchical_four_class_aic():
-    _test_hierarchical_four_class(cluster_kws=dict(selection_criteria="aic"))
+    def test_predict_without_fit(self):
+        # Generate random data
+        X = np.random.normal(0, 1, size=(100, 3))
+
+        with self.assertRaises(NotFittedError):
+            dc = DivisiveCluster(max_components=2)
+            dc.predict(X)
 
 
-def test_hierarchical_four_class_kmeans():
-    _test_hierarchical_four_class(cluster_method="kmeans")
+    def test_predict_on_nonfitted_data_gmm(self):
+        # Generate random data to fit on
+        np.random.seed(1)
+        n = 100
+        d = 3
+        X1 = np.random.normal(1, 0.1, size=(n, d))
+        X2 = np.random.normal(2, 0.1, size=(n, d))
+        X = np.vstack((X1, X2))
+        y = np.repeat([0, 1], n)
+
+        dc = DivisiveCluster(max_components=2)
+        pred1 = dc.fit_predict(X)
+
+        # Generate random data to predict on
+        np.random.seed(2)
+        n = 50
+        d = 3
+        X1_new = np.random.normal(1, 0.1, size=(n, d))
+        X2_new = np.random.normal(2, 0.1, size=(n, d))
+        X_new = np.vstack((X1_new, X2_new))
+        y_new = np.repeat([0, 1], n)
+
+        pred2 = dc.predict(X_new)
+
+        # Assert that both predictions have the same depth
+        assert_equal(pred1.shape[1], pred2.shape[1])
+
+        # Assert that both predictions represent a perfect clustering
+        # of 2 clusters
+        assert_equal(np.max(pred1) + 1, 2)
+        ari_1 = adjusted_rand_score(y, pred1[:, 0])
+        assert_allclose(ari_1, 1)
+
+        assert_equal(np.max(pred2) + 1, 2)
+        ari_2 = adjusted_rand_score(y_new, pred2[:, 0])
+        assert_allclose(ari_2, 1)
 
 
-def test_hierarchical_six_class_delta_criter():
-    """
-    Clustering on less easily separable hierarchical data with 2 levels
-    of six gaussians
-    """
+    def test_predict_on_nonfitted_data_kmeans(self):
+        # Generate random data to fit on
+        np.random.seed(1)
+        n = 100
+        d = 3
+        X1 = np.random.normal(1, 0.1, size=(n, d))
+        X2 = np.random.normal(2, 0.1, size=(n, d))
+        X = np.vstack((X1, X2))
+        y = np.repeat([0, 1], n)
 
-    np.random.seed(1)
+        dc = DivisiveCluster(max_components=2, cluster_method="kmeans")
+        pred1 = dc.fit_predict(X)
 
-    n = 100
-    d = 3
+        # Generate random data to predict on
+        np.random.seed(2)
+        n = 50
+        d = 3
+        X1_new = np.random.normal(1, 0.1, size=(n, d))
+        X2_new = np.random.normal(2, 0.1, size=(n, d))
+        X_new = np.vstack((X1_new, X2_new))
+        y_new = np.repeat([0, 1], n)
 
-    X11 = np.random.normal(-4, 0.8, size=(n, d))
-    X21 = np.random.normal(-3, 0.8, size=(n, d))
-    X31 = np.random.normal(-2, 0.8, size=(n, d))
-    X12 = np.random.normal(2, 0.8, size=(n, d))
-    X22 = np.random.normal(3, 0.8, size=(n, d))
-    X32 = np.random.normal(4, 0.8, size=(n, d))
-    X = np.vstack((X11, X21, X31, X12, X22, X32))
+        pred2 = dc.predict(X_new)
 
-    y_lvl1 = np.repeat([0, 1], 3 * n)
-    y_lvl2 = np.repeat([0, 1, 2, 3, 4, 5], n)
+        # Assert that both predictions have the same depth
+        assert_equal(pred1.shape[1], pred2.shape[1])
 
-    # Perform clustering without setting delta_criter
-    dc = DivisiveCluster(max_components=2)
-    pred = dc.fit_predict(X, fcluster=True)
+        # Assert that both predictions represent a perfect clustering
+        # of 2 clusters at 1st level
+        assert_equal(np.max(pred1[:, 0]) + 1, 2)
+        ari_1 = adjusted_rand_score(y, pred1[:, 0])
+        assert_allclose(ari_1, 1)
 
-    # Perform clustering while setting delta_criter
-    dc = DivisiveCluster(max_components=2, delta_criter=10)
-    pred_delta_criter = dc.fit_predict(X, fcluster=True)
+        assert_equal(np.max(pred2[:, 0]) + 1, 2)
+        ari_2 = adjusted_rand_score(y_new, pred2[:, 0])
+        assert_allclose(ari_2, 1)
 
-    # Assert that pred has more levels than pred_delta_criter
-    assert_equal(pred.shape[1] - 1, pred_delta_criter.shape[1])
+        # Assert that predictions on new data have the same or fewer
+        # clusters than those on the fitted data at each level
+        for lvl in range(pred1.shape[1]):
+            n_cluster1 = np.max(pred1[:, lvl]) + 1
+            n_cluster2 = np.max(pred2[:, lvl]) + 1
+            assert_array_less(n_cluster2, n_cluster1 + 1)
 
-    # Assert that both pred_delta_criter and pred represent
-    # perfect clustering at the first level
-    ari_lvl1 = adjusted_rand_score(y_lvl1, pred[:, 0])
-    assert_allclose(ari_lvl1, 1)
-    ari_delta_criter_lvl1 = adjusted_rand_score(y_lvl1, pred_delta_criter[:, 0])
-    assert_allclose(ari_delta_criter_lvl1, 1)
 
-    # Assert that pred_delta_criter leads to a clustering as good as
-    # pred at the second level
-    ari_lvl2 = adjusted_rand_score(y_lvl2, pred[:, 1])
-    ari_delta_criter_lvl2 = adjusted_rand_score(y_lvl2, pred_delta_criter[:, 1])
-    assert_allclose(ari_delta_criter_lvl2, ari_lvl2)
+    def test_hierarchical_four_class_gmm(self):
+        _test_hierarchical_four_class(cluster_method="gmm")
+    
 
-    # Assert that pred suggests oversplitting at the last level (level 3)
-    # which leads to a worse clustering than the last level
-    # of pred_delta_criter (level 2)
-    ari_lvl3 = adjusted_rand_score(y_lvl2, pred[:, -1])
-    assert_array_less(ari_lvl3, ari_delta_criter_lvl2)
+    def test_hierarchical_four_class_aic(self):
+        _test_hierarchical_four_class(cluster_kws=dict(selection_criteria="aic"))
+
+
+    def test_hierarchical_four_class_kmeans(self):
+        _test_hierarchical_four_class(cluster_method="kmeans")
+
+
+    def test_hierarchical_six_class_delta_criter(self):
+        """
+        Clustering on less easily separable hierarchical data with 2 levels
+        of six gaussians
+        """
+
+        np.random.seed(1)
+
+        n = 100
+        d = 3
+
+        X11 = np.random.normal(-4, 0.8, size=(n, d))
+        X21 = np.random.normal(-3, 0.8, size=(n, d))
+        X31 = np.random.normal(-2, 0.8, size=(n, d))
+        X12 = np.random.normal(2, 0.8, size=(n, d))
+        X22 = np.random.normal(3, 0.8, size=(n, d))
+        X32 = np.random.normal(4, 0.8, size=(n, d))
+        X = np.vstack((X11, X21, X31, X12, X22, X32))
+
+        y_lvl1 = np.repeat([0, 1], 3 * n)
+        y_lvl2 = np.repeat([0, 1, 2, 3, 4, 5], n)
+
+        # Perform clustering without setting delta_criter
+        dc = DivisiveCluster(max_components=2)
+        pred = dc.fit_predict(X, fcluster=True)
+
+        # Perform clustering while setting delta_criter
+        dc = DivisiveCluster(max_components=2, delta_criter=10)
+        pred_delta_criter = dc.fit_predict(X, fcluster=True)
+
+        # Assert that pred has more levels than pred_delta_criter
+        assert_equal(pred.shape[1] - 1, pred_delta_criter.shape[1])
+
+        # Assert that both pred_delta_criter and pred represent
+        # perfect clustering at the first level
+        ari_lvl1 = adjusted_rand_score(y_lvl1, pred[:, 0])
+        assert_allclose(ari_lvl1, 1)
+        ari_delta_criter_lvl1 = adjusted_rand_score(y_lvl1, pred_delta_criter[:, 0])
+        assert_allclose(ari_delta_criter_lvl1, 1)
+
+        # Assert that pred_delta_criter leads to a clustering as good as
+        # pred at the second level
+        ari_lvl2 = adjusted_rand_score(y_lvl2, pred[:, 1])
+        ari_delta_criter_lvl2 = adjusted_rand_score(y_lvl2, pred_delta_criter[:, 1])
+        assert_allclose(ari_delta_criter_lvl2, ari_lvl2)
+
+        # Assert that pred suggests oversplitting at the last level (level 3)
+        # which leads to a worse clustering than the last level
+        # of pred_delta_criter (level 2)
+        ari_lvl3 = adjusted_rand_score(y_lvl2, pred[:, -1])
+        assert_array_less(ari_lvl3, ari_delta_criter_lvl2)

--- a/tests/cluster/test_divisive_cluster.py
+++ b/tests/cluster/test_divisive_cluster.py
@@ -127,7 +127,6 @@ class TestDivisiveCluster(unittest.TestCase):
             dc.fit(X)
             dc.predict(X, level=1)
 
-
     def test_predict_without_fit(self):
         # Generate random data
         X = np.random.normal(0, 1, size=(100, 3))
@@ -135,7 +134,6 @@ class TestDivisiveCluster(unittest.TestCase):
         with self.assertRaises(NotFittedError):
             dc = DivisiveCluster(max_components=2)
             dc.predict(X)
-
 
     def test_predict_on_nonfitted_data_gmm(self):
         # Generate random data to fit on
@@ -173,7 +171,6 @@ class TestDivisiveCluster(unittest.TestCase):
         assert_equal(np.max(pred2) + 1, 2)
         ari_2 = adjusted_rand_score(y_new, pred2[:, 0])
         assert_allclose(ari_2, 1)
-
 
     def test_predict_on_nonfitted_data_kmeans(self):
         # Generate random data to fit on
@@ -219,18 +216,14 @@ class TestDivisiveCluster(unittest.TestCase):
             n_cluster2 = np.max(pred2[:, lvl]) + 1
             assert_array_less(n_cluster2, n_cluster1 + 1)
 
-
     def test_hierarchical_four_class_gmm(self):
         _test_hierarchical_four_class(cluster_method="gmm")
-    
 
     def test_hierarchical_four_class_aic(self):
         _test_hierarchical_four_class(cluster_kws=dict(selection_criteria="aic"))
 
-
     def test_hierarchical_four_class_kmeans(self):
         _test_hierarchical_four_class(cluster_method="kmeans")
-
 
     def test_hierarchical_six_class_delta_criter(self):
         """

--- a/tests/cluster/test_gclust.py
+++ b/tests/cluster/test_gclust.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import pytest
+import unittest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from sklearn.exceptions import NotFittedError
@@ -11,240 +11,241 @@ from graspologic.embed.ase import AdjacencySpectralEmbed
 from graspologic.simulations.simulations import sbm
 
 
-def test_inputs():
-    # Generate random data
-    X = np.random.normal(0, 1, size=(100, 3))
+class TestGaussianCluster(unittest.TestCase):
+    def test_inputs(self):
+        # Generate random data
+        X = np.random.normal(0, 1, size=(100, 3))
 
-    # min_components < 1
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(min_components=0)
+        # min_components < 1
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(min_components=0)
 
-    # min_components integer
-    with pytest.raises(TypeError):
-        gclust = GaussianCluster(min_components="1")
+        # min_components integer
+        with self.assertRaises(TypeError):
+            gclust = GaussianCluster(min_components="1")
 
-    # max_components < min_components
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(min_components=1, max_components=0)
+        # max_components < min_components
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(min_components=1, max_components=0)
 
-    # max_components integer
-    with pytest.raises(TypeError):
-        gclust = GaussianCluster(min_components=1, max_components="1")
+        # max_components integer
+        with self.assertRaises(TypeError):
+            gclust = GaussianCluster(min_components=1, max_components="1")
 
-    # covariance type is not an array, string or list
-    with pytest.raises(TypeError):
-        gclust = GaussianCluster(min_components=1, covariance_type=1)
+        # covariance type is not an array, string or list
+        with self.assertRaises(TypeError):
+            gclust = GaussianCluster(min_components=1, covariance_type=1)
 
-    # covariance type is not in ['spherical', 'diag', 'tied', 'full']
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(min_components=1, covariance_type="graspologic")
+        # covariance type is not in ['spherical', 'diag', 'tied', 'full']
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(min_components=1, covariance_type="graspologic")
 
-    # min_cluster > n_samples when max_cluster is None
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(1000)
-        gclust.fit(X)
+        # min_cluster > n_samples when max_cluster is None
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(1000)
+            gclust.fit(X)
 
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(1000)
-        gclust.fit_predict(X)
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(1000)
+            gclust.fit_predict(X)
 
-    # max_cluster > n_samples when max_cluster is not None
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(10, 1001)
-        gclust.fit(X)
+        # max_cluster > n_samples when max_cluster is not None
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(10, 1001)
+            gclust.fit(X)
 
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(10, 1001)
-        gclust.fit_predict(X)
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(10, 1001)
+            gclust.fit_predict(X)
 
-    # min_cluster > n_samples when max_cluster is None
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(1000)
-        gclust.fit(X)
+        # min_cluster > n_samples when max_cluster is None
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(1000)
+            gclust.fit(X)
 
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(10, 1001)
-        gclust.fit_predict(X)
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(10, 1001)
+            gclust.fit_predict(X)
 
-    # min_cluster > n_samples when max_cluster is not None
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(1000, 1001)
-        gclust.fit(X)
+        # min_cluster > n_samples when max_cluster is not None
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(1000, 1001)
+            gclust.fit(X)
 
-    with pytest.raises(ValueError):
-        gclust = GaussianCluster(1000, 1001)
-        gclust.fit_predict(X)
-
-
-def test_predict_without_fit():
-    # Generate random data
-    X = np.random.normal(0, 1, size=(100, 3))
-
-    with pytest.raises(NotFittedError):
-        gclust = GaussianCluster(min_components=2)
-        gclust.predict(X)
+        with self.assertRaises(ValueError):
+            gclust = GaussianCluster(1000, 1001)
+            gclust.fit_predict(X)
 
 
-def test_no_y():
-    np.random.seed(2)
+    def test_predict_without_fit(self):
+        # Generate random data
+        X = np.random.normal(0, 1, size=(100, 3))
 
-    n = 100
-    d = 3
-
-    X1 = np.random.normal(2, 0.5, size=(n, d))
-    X2 = np.random.normal(-2, 0.5, size=(n, d))
-    X = np.vstack((X1, X2))
-
-    gclust = GaussianCluster(min_components=5, n_init=2)
-    gclust.fit(X)
-
-    assert_equal(gclust.n_components_, 2)
+        with self.assertRaises(NotFittedError):
+            gclust = GaussianCluster(min_components=2)
+            gclust.predict(X)
 
 
-def test_two_class():
-    """
-    Easily separable two gaussian problem.
-    """
-    np.random.seed(2)
+    def test_no_y(self):
+        np.random.seed(2)
 
-    n = 100
-    d = 3
+        n = 100
+        d = 3
 
-    num_sims = 10
-
-    for _ in range(num_sims):
         X1 = np.random.normal(2, 0.5, size=(n, d))
         X2 = np.random.normal(-2, 0.5, size=(n, d))
         X = np.vstack((X1, X2))
-        y = np.repeat([0, 1], n)
 
-        gclust = GaussianCluster(min_components=5)
-        gclust.fit(X, y)
-
-        n_components = gclust.n_components_
-
-        # Assert that the two cluster model is the best
-        assert_equal(n_components, 2)
-
-        # Asser that we get perfect clustering
-        assert_allclose(gclust.ari_.loc[n_components], 1)
-
-
-def test_five_class():
-    """
-    Easily separable five gaussian problem.
-    """
-    np.random.seed(10)
-
-    n = 100
-    mus = [[i * 5, 0] for i in range(5)]
-    cov = np.eye(2)  # balls
-
-    num_sims = 10
-
-    for _ in range(num_sims):
-        X = np.vstack([np.random.multivariate_normal(mu, cov, n) for mu in mus])
-
-        gclust = GaussianCluster(
-            min_components=3, max_components=10, covariance_type="all"
-        )
+        gclust = GaussianCluster(min_components=5, n_init=2)
         gclust.fit(X)
-        assert_equal(gclust.n_components_, 5)
+
+        assert_equal(gclust.n_components_, 2)
 
 
-def test_ase_three_blocks():
-    """
-    Expect 3 clusters from a 3 block model
-    """
-    np.random.seed(3)
-    num_sims = 10
+    def test_two_class(self):
+        """
+        Easily separable two gaussian problem.
+        """
+        np.random.seed(2)
 
-    # Generate adjacency and labels
-    n = 50
-    n_communites = [n, n, n]
-    p = np.array([[0.8, 0.3, 0.2], [0.3, 0.8, 0.3], [0.2, 0.3, 0.8]])
-    y = np.repeat([1, 2, 3], repeats=n)
+        n = 100
+        d = 3
 
-    for _ in range(num_sims):
-        A = sbm(n=n_communites, p=p)
+        num_sims = 10
 
-        # Embed to get latent positions
-        ase = AdjacencySpectralEmbed(n_components=5)
-        X_hat = ase.fit_transform(A)
+        for _ in range(num_sims):
+            X1 = np.random.normal(2, 0.5, size=(n, d))
+            X2 = np.random.normal(-2, 0.5, size=(n, d))
+            X = np.vstack((X1, X2))
+            y = np.repeat([0, 1], n)
 
-        # Compute clusters
-        gclust = GaussianCluster(min_components=10)
-        gclust.fit(X_hat, y)
+            gclust = GaussianCluster(min_components=5)
+            gclust.fit(X, y)
 
-        n_components = gclust.n_components_
+            n_components = gclust.n_components_
 
-        # Assert that the three cluster model is the best
-        assert_equal(n_components, 3)
+            # Assert that the two cluster model is the best
+            assert_equal(n_components, 2)
 
-        # Asser that we get perfect clustering
-        assert_allclose(gclust.ari_.loc[n_components], 1)
+            # Asser that we get perfect clustering
+            assert_allclose(gclust.ari_.loc[n_components], 1)
 
 
-def test_covariances():
-    """
-    Easily separable two gaussian problem.
-    """
-    np.random.seed(2)
+    def test_five_class(self):
+        """
+        Easily separable five gaussian problem.
+        """
+        np.random.seed(10)
 
-    n = 100
+        n = 100
+        mus = [[i * 5, 0] for i in range(5)]
+        cov = np.eye(2)  # balls
 
-    mu1 = [-10, 0]
-    mu2 = [10, 0]
+        num_sims = 10
 
-    # Spherical
-    cov1 = 2 * np.eye(2)
-    cov2 = 2 * np.eye(2)
+        for _ in range(num_sims):
+            X = np.vstack([np.random.multivariate_normal(mu, cov, n) for mu in mus])
 
-    X1 = np.random.multivariate_normal(mu1, cov1, n)
-    X2 = np.random.multivariate_normal(mu2, cov2, n)
+            gclust = GaussianCluster(
+                min_components=3, max_components=10, covariance_type="all"
+            )
+            gclust.fit(X)
+            assert_equal(gclust.n_components_, 5)
 
-    X = np.concatenate((X1, X2))
 
-    gclust = GaussianCluster(min_components=2, covariance_type="all")
-    gclust.fit(X)
-    assert_equal(gclust.covariance_type_, "spherical")
+    def test_ase_three_blocks(self):
+        """
+        Expect 3 clusters from a 3 block model
+        """
+        np.random.seed(3)
+        num_sims = 10
 
-    # Diagonal
-    np.random.seed(10)
-    cov1 = np.diag([1, 1])
-    cov2 = np.diag([2, 1])
+        # Generate adjacency and labels
+        n = 50
+        n_communites = [n, n, n]
+        p = np.array([[0.8, 0.3, 0.2], [0.3, 0.8, 0.3], [0.2, 0.3, 0.8]])
+        y = np.repeat([1, 2, 3], repeats=n)
 
-    X1 = np.random.multivariate_normal(mu1, cov1, n)
-    X2 = np.random.multivariate_normal(mu2, cov2, n)
+        for _ in range(num_sims):
+            A = sbm(n=n_communites, p=p)
 
-    X = np.concatenate((X1, X2))
+            # Embed to get latent positions
+            ase = AdjacencySpectralEmbed(n_components=5)
+            X_hat = ase.fit_transform(A)
 
-    gclust = GaussianCluster(min_components=2, covariance_type="all")
-    gclust.fit(X)
-    assert_equal(gclust.covariance_type_, "diag")
+            # Compute clusters
+            gclust = GaussianCluster(min_components=10)
+            gclust.fit(X_hat, y)
 
-    # Tied
-    cov1 = np.array([[2, 1], [1, 2]])
-    cov2 = np.array([[2, 1], [1, 2]])
+            n_components = gclust.n_components_
 
-    X1 = np.random.multivariate_normal(mu1, cov1, n)
-    X2 = np.random.multivariate_normal(mu2, cov2, n)
+            # Assert that the three cluster model is the best
+            assert_equal(n_components, 3)
 
-    X = np.concatenate((X1, X2))
+            # Asser that we get perfect clustering
+            assert_allclose(gclust.ari_.loc[n_components], 1)
 
-    gclust = GaussianCluster(min_components=2, covariance_type="all")
-    gclust.fit(X)
-    assert_equal(gclust.covariance_type_, "tied")
 
-    # Full
-    cov1 = np.array([[2, -1], [-1, 2]])
-    cov2 = np.array([[2, 1], [1, 2]])
+    def test_covariances(self):
+        """
+        Easily separable two gaussian problem.
+        """
+        np.random.seed(2)
 
-    X1 = np.random.multivariate_normal(mu1, cov1, n)
-    X2 = np.random.multivariate_normal(mu2, cov2, n)
+        n = 100
 
-    X = np.concatenate((X1, X2))
+        mu1 = [-10, 0]
+        mu2 = [10, 0]
 
-    gclust = GaussianCluster(min_components=2, covariance_type="all")
-    gclust.fit(X)
-    assert_equal(gclust.covariance_type_, "full")
+        # Spherical
+        cov1 = 2 * np.eye(2)
+        cov2 = 2 * np.eye(2)
+
+        X1 = np.random.multivariate_normal(mu1, cov1, n)
+        X2 = np.random.multivariate_normal(mu2, cov2, n)
+
+        X = np.concatenate((X1, X2))
+
+        gclust = GaussianCluster(min_components=2, covariance_type="all")
+        gclust.fit(X)
+        assert_equal(gclust.covariance_type_, "spherical")
+
+        # Diagonal
+        np.random.seed(10)
+        cov1 = np.diag([1, 1])
+        cov2 = np.diag([2, 1])
+
+        X1 = np.random.multivariate_normal(mu1, cov1, n)
+        X2 = np.random.multivariate_normal(mu2, cov2, n)
+
+        X = np.concatenate((X1, X2))
+
+        gclust = GaussianCluster(min_components=2, covariance_type="all")
+        gclust.fit(X)
+        assert_equal(gclust.covariance_type_, "diag")
+
+        # Tied
+        cov1 = np.array([[2, 1], [1, 2]])
+        cov2 = np.array([[2, 1], [1, 2]])
+
+        X1 = np.random.multivariate_normal(mu1, cov1, n)
+        X2 = np.random.multivariate_normal(mu2, cov2, n)
+
+        X = np.concatenate((X1, X2))
+
+        gclust = GaussianCluster(min_components=2, covariance_type="all")
+        gclust.fit(X)
+        assert_equal(gclust.covariance_type_, "tied")
+
+        # Full
+        cov1 = np.array([[2, -1], [-1, 2]])
+        cov2 = np.array([[2, 1], [1, 2]])
+
+        X1 = np.random.multivariate_normal(mu1, cov1, n)
+        X2 = np.random.multivariate_normal(mu2, cov2, n)
+
+        X = np.concatenate((X1, X2))
+
+        gclust = GaussianCluster(min_components=2, covariance_type="all")
+        gclust.fit(X)
+        assert_equal(gclust.covariance_type_, "full")

--- a/tests/cluster/test_gclust.py
+++ b/tests/cluster/test_gclust.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import unittest
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from sklearn.exceptions import NotFittedError

--- a/tests/cluster/test_gclust.py
+++ b/tests/cluster/test_gclust.py
@@ -77,7 +77,6 @@ class TestGaussianCluster(unittest.TestCase):
             gclust = GaussianCluster(1000, 1001)
             gclust.fit_predict(X)
 
-
     def test_predict_without_fit(self):
         # Generate random data
         X = np.random.normal(0, 1, size=(100, 3))
@@ -85,7 +84,6 @@ class TestGaussianCluster(unittest.TestCase):
         with self.assertRaises(NotFittedError):
             gclust = GaussianCluster(min_components=2)
             gclust.predict(X)
-
 
     def test_no_y(self):
         np.random.seed(2)
@@ -101,7 +99,6 @@ class TestGaussianCluster(unittest.TestCase):
         gclust.fit(X)
 
         assert_equal(gclust.n_components_, 2)
-
 
     def test_two_class(self):
         """
@@ -131,7 +128,6 @@ class TestGaussianCluster(unittest.TestCase):
             # Asser that we get perfect clustering
             assert_allclose(gclust.ari_.loc[n_components], 1)
 
-
     def test_five_class(self):
         """
         Easily separable five gaussian problem.
@@ -152,7 +148,6 @@ class TestGaussianCluster(unittest.TestCase):
             )
             gclust.fit(X)
             assert_equal(gclust.n_components_, 5)
-
 
     def test_ase_three_blocks(self):
         """
@@ -185,7 +180,6 @@ class TestGaussianCluster(unittest.TestCase):
 
             # Asser that we get perfect clustering
             assert_allclose(gclust.ari_.loc[n_components], 1)
-
 
     def test_covariances(self):
         """

--- a/tests/cluster/test_kclust.py
+++ b/tests/cluster/test_kclust.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import unittest
+
 import numpy as np
 from numpy.testing import assert_equal
 from sklearn.exceptions import NotFittedError

--- a/tests/cluster/test_kclust.py
+++ b/tests/cluster/test_kclust.py
@@ -1,70 +1,68 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import pytest
+import unittest
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_equal
 from sklearn.exceptions import NotFittedError
 
 from graspologic.cluster.kclust import KMeansCluster
 
 
-def test_inputs():
-    # Generate random data
-    X = np.random.normal(0, 1, size=(100, 3))
+class TestKMeansCluster(unittest.TestCase):
+    def test_inputs(self):
+        # Generate random data
+        X = np.random.normal(0, 1, size=(100, 3))
 
-    with pytest.raises(TypeError):
-        max_clusters = "1"
-        kclust = KMeansCluster(max_clusters=max_clusters)
+        with self.assertRaises(TypeError):
+            max_clusters = "1"
+            kclust = KMeansCluster(max_clusters=max_clusters)
 
-    # max_cluster < 0
-    with pytest.raises(ValueError):
-        kclust = KMeansCluster(max_clusters=-1)
+        # max_cluster < 0
+        with self.assertRaises(ValueError):
+            kclust = KMeansCluster(max_clusters=-1)
 
-    # max_cluster more than n_samples
-    with pytest.raises(ValueError):
-        kclust = KMeansCluster(max_clusters=1000)
-        kclust.fit_predict(X)
+        # max_cluster more than n_samples
+        with self.assertRaises(ValueError):
+            kclust = KMeansCluster(max_clusters=1000)
+            kclust.fit_predict(X)
 
+    def test_predict_without_fit(self):
+        # Generate random data
+        X = np.random.normal(0, 1, size=(100, 3))
 
-def test_predict_without_fit():
-    # Generate random data
-    X = np.random.normal(0, 1, size=(100, 3))
+        with self.assertRaises(NotFittedError):
+            kclust = KMeansCluster(max_clusters=2)
+            kclust.predict(X)
 
-    with pytest.raises(NotFittedError):
-        kclust = KMeansCluster(max_clusters=2)
-        kclust.predict(X)
+    def test_outputs_gaussians(self):
+        np.random.seed(2)
 
+        n = 100
+        d = 3
+        num_sims = 10
+        for _ in range(num_sims):
+            X1 = np.random.normal(2, 0.5, size=(n, d))
+            X2 = np.random.normal(-2, 0.5, size=(n, d))
+            X = np.vstack((X1, X2))
+            y = np.repeat([0, 1], n)
 
-def test_outputs_gaussians():
-    np.random.seed(2)
+            kclust = KMeansCluster(max_clusters=5)
+            kclust.fit(X, y)
+            aris = kclust.ari_
 
-    n = 100
-    d = 3
-    num_sims = 10
-    for _ in range(num_sims):
+            # Assert that the two cluster model is the best
+            assert_equal(np.max(aris), 1)
+
+    def test_no_y(self):
+        np.random.seed(2)
+        n = 100
+        d = 3
         X1 = np.random.normal(2, 0.5, size=(n, d))
         X2 = np.random.normal(-2, 0.5, size=(n, d))
         X = np.vstack((X1, X2))
-        y = np.repeat([0, 1], n)
 
         kclust = KMeansCluster(max_clusters=5)
-        kclust.fit(X, y)
-        aris = kclust.ari_
+        kclust.fit(X)
 
-        # Assert that the two cluster model is the best
-        assert_equal(np.max(aris), 1)
-
-
-def test_no_y():
-    np.random.seed(2)
-    n = 100
-    d = 3
-    X1 = np.random.normal(2, 0.5, size=(n, d))
-    X2 = np.random.normal(-2, 0.5, size=(n, d))
-    X = np.vstack((X1, X2))
-
-    kclust = KMeansCluster(max_clusters=5)
-    kclust.fit(X)
-
-    assert_equal(np.argmax(kclust.silhouette_), 0)
+        assert_equal(np.argmax(kclust.silhouette_), 0)

--- a/tests/embed/test_n2v.py
+++ b/tests/embed/test_n2v.py
@@ -1,12 +1,12 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import networkx as nx
-import numpy as np
 import unittest
 
-from sklearn.metrics import adjusted_rand_score
+import networkx as nx
+import numpy as np
 from sklearn.cluster import KMeans
+from sklearn.metrics import adjusted_rand_score
 
 import graspologic as gc
 

--- a/tests/layouts/nooverlap/test_grid.py
+++ b/tests/layouts/nooverlap/test_grid.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import unittest
+
 from graspologic.layouts.nooverlap._grid import _GridBuckets
 from graspologic.layouts.nooverlap._node import _Node
 

--- a/tests/layouts/nooverlap/test_grid_cell_creation.py
+++ b/tests/layouts/nooverlap/test_grid_cell_creation.py
@@ -2,8 +2,9 @@
 # Licensed under the MIT License.
 
 import unittest
-from graspologic.layouts.nooverlap._quad_node import _QuadNode
+
 from graspologic.layouts.nooverlap._node import _Node
+from graspologic.layouts.nooverlap._quad_node import _QuadNode
 
 
 class TestGridCellCreation(unittest.TestCase):

--- a/tests/layouts/nooverlap/test_nooverlap.py
+++ b/tests/layouts/nooverlap/test_nooverlap.py
@@ -2,14 +2,15 @@
 # Licensed under the MIT License.
 
 import unittest
+
+from graspologic.layouts import NodePosition
+from graspologic.layouts.nooverlap._node import _Node
 from graspologic.layouts.nooverlap._quad_node import (
-    move_point_on_line,
     _QuadNode,
+    move_point_on_line,
     node_positions_overlap,
 )
-from graspologic.layouts.nooverlap._node import _Node
 from graspologic.layouts.nooverlap.nooverlap import remove_overlaps
-from graspologic.layouts import NodePosition
 
 
 class TestNoOverlap(unittest.TestCase):

--- a/tests/layouts/nooverlap/test_overlap_check.py
+++ b/tests/layouts/nooverlap/test_overlap_check.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import unittest
+
 from graspologic.layouts.nooverlap._node import _Node
 from graspologic.layouts.nooverlap._quad_node import (
     _QuadNode,

--- a/tests/layouts/test_auto.py
+++ b/tests/layouts/test_auto.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import unittest
+
 import networkx as nx
 import numpy
 

--- a/tests/partition/test_leiden.py
+++ b/tests/partition/test_leiden.py
@@ -1,16 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import unittest
 from typing import List, Tuple
 
-import unittest
 import networkx as nx
 import numpy as np
 import scipy
 
 from graspologic.partition import HierarchicalCluster, hierarchical_leiden, leiden
-from graspologic.partition.leiden import _validate_and_build_edge_list, _from_native
-
+from graspologic.partition.leiden import _from_native, _validate_and_build_edge_list
 from tests.utils import data_file
 
 

--- a/tests/partition/test_modularity.py
+++ b/tests/partition/test_modularity.py
@@ -1,12 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import networkx as nx
-import numpy as np
-from graspologic.partition import modularity, modularity_components
 import unittest
 from typing import Dict
 
+import networkx as nx
+import numpy as np
+
+from graspologic.partition import modularity, modularity_components
 from tests.utils import data_file
 
 

--- a/tests/pipeline/embed/test_adjacency_spectral_embedding.py
+++ b/tests/pipeline/embed/test_adjacency_spectral_embedding.py
@@ -9,7 +9,6 @@ import numpy as np
 import graspologic.utils
 from graspologic.embed import AdjacencySpectralEmbed
 from graspologic.pipeline.embed import adjacency_spectral_embedding
-
 from tests.utils import data_file
 
 

--- a/tests/preprocessing/graph_cuts.py
+++ b/tests/preprocessing/graph_cuts.py
@@ -2,13 +2,14 @@
 # Licensed under the MIT License.
 
 import unittest
-import numpy as np
+
 import networkx as nx
+import numpy as np
+from testfixtures import LogCapture
 
 from graspologic.preprocessing import graph_cuts
-from ..utils import data_file
 
-from testfixtures import LogCapture
+from ..utils import data_file
 
 
 def _get_florentine_graph():

--- a/tests/test_casc.py
+++ b/tests/test_casc.py
@@ -1,11 +1,13 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import pytest
 import unittest
+
 import numpy as np
+import pytest
 from scipy.stats import beta
 from sklearn.mixture import GaussianMixture
+
 from graspologic.embed.case import CovariateAssistedEmbed as CASE
 from graspologic.simulations import sbm
 

--- a/tests/test_casc.py
+++ b/tests/test_casc.py
@@ -1,13 +1,15 @@
+# Copyright (c) Microsoft Corporation and contributors.
+# Licensed under the MIT License.
+
 import pytest
-from pytest import mark
+import unittest
 import numpy as np
 from scipy.stats import beta
 from sklearn.mixture import GaussianMixture
 from graspologic.embed.case import CovariateAssistedEmbed as CASE
 from graspologic.simulations import sbm
-from graspologic.utils import is_almost_symmetric
 
-np.random.seed(420)
+np.random.seed(5)
 
 # UTILITY FUNCTIONS
 def gen_covariates(m1, m2, labels, type, ndim=3):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,19 +1,18 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import pytest
+import unittest
 from graspologic.datasets import *
 
 
-def test_drosphila_left():
-    graph = load_drosophila_left()
-    graph, labels = load_drosophila_left(return_labels=True)
+class TestDatasets(unittest.TestCase):
+    def test_drosphila_left(self):
+        graph = load_drosophila_left()
+        graph, labels = load_drosophila_left(return_labels=True)
 
+    def test_drosphila_right(self):
+        graph = load_drosophila_right()
+        graph, labels = load_drosophila_right(return_labels=True)
 
-def test_drosphila_right():
-    graph = load_drosophila_right()
-    graph, labels = load_drosophila_right(return_labels=True)
-
-
-def test_load_mice():
-    data = load_mice()
+    def test_load_mice(self):
+        data = load_mice()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import unittest
+
 from graspologic.datasets import *
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,13 +1,13 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
+import os
 import tempfile
+import unittest
 from pathlib import Path
 
 import networkx as nx
 import numpy as np
-import unittest
-import os
 
 import graspologic as gs
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -47,7 +47,6 @@ class TestImportGraph(unittest.TestCase):
 
 
 class TestImportEdgelist(unittest.TestCase):
-
     @classmethod
     def tearDownClass(cls) -> None:
         cls.tmpdir.cleanup()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,19 +1,20 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import sys
+import tempfile
 from pathlib import Path
 
 import networkx as nx
 import numpy as np
-import pytest
+import unittest
+import os
 
 import graspologic as gs
 
 
-class TestImportGraph:
+class TestImportGraph(unittest.TestCase):
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls) -> None:
         # simple ERxN graph
         n = 15
         p = 0.5
@@ -34,20 +35,26 @@ class TestImportGraph:
 
     def test_wrongtypein(self):
         a = 5
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             gs.utils.import_graph(a)
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             gs.utils.import_graph(None)
 
     def test_nonsquare(self):
         non_square = np.hstack((self.A, self.A))
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             gs.utils.import_graph(non_square)
 
 
-class TestImportEdgelist:
-    @pytest.fixture(autouse=True)
-    def setup_class(self, tmpdir):
+class TestImportEdgelist(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.tmpdir.cleanup()
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tmpdir = tempfile.TemporaryDirectory()
         n = 10
         p = 0.5
         wt = np.random.exponential
@@ -55,33 +62,33 @@ class TestImportEdgelist:
 
         np.random.seed(1)
 
-        self.A = gs.simulations.er_np(n, p)
-        self.B = gs.simulations.er_np(n, p, wt=wt, wtargs=wtargs)
+        cls.A = gs.simulations.er_np(n, p)
+        cls.B = gs.simulations.er_np(n, p, wt=wt, wtargs=wtargs)
 
-        G_A = nx.from_numpy_array(self.A)
-        G_B = nx.from_numpy_array(self.B)
+        G_A = nx.from_numpy_array(cls.A)
+        G_B = nx.from_numpy_array(cls.B)
         G_B = nx.relabel_nodes(G_B, lambda x: x + 10)  # relabel nodes to go from 10-19.
 
-        self.A_path = str(tmpdir / "A_unweighted.edgelist")
-        self.B_path = str(tmpdir / "B.edgelist")
-        self.root = str(tmpdir)
+        cls.root = str(cls.tmpdir.name)
+        cls.A_path = os.path.join(cls.root, "A_unweighted.edgelist")
+        cls.B_path = os.path.join(cls.root, "B.edgelist")
 
-        nx.write_edgelist(G_A, self.A_path, data=False)
-        nx.write_weighted_edgelist(G_B, self.B_path)
+        nx.write_edgelist(G_A, cls.A_path, data=False)
+        nx.write_weighted_edgelist(G_B, cls.B_path)
 
     def test_in(self):
         A_from_edgelist = gs.utils.import_edgelist(self.A_path)
         B_from_edgelist = gs.utils.import_edgelist(self.B_path)
 
-        assert np.allclose(A_from_edgelist, self.A)
-        assert np.allclose(B_from_edgelist, self.B)
+        np.testing.assert_allclose(A_from_edgelist, self.A)
+        np.testing.assert_allclose(B_from_edgelist, self.B)
 
     def test_in_Path_obj(self):
         A_from_edgelist = gs.utils.import_edgelist(Path(self.A_path))
         B_from_edgelist = gs.utils.import_edgelist(Path(self.B_path))
 
-        assert np.allclose(A_from_edgelist, self.A)
-        assert np.allclose(B_from_edgelist, self.B)
+        np.testing.assert_allclose(A_from_edgelist, self.A)
+        np.testing.assert_allclose(B_from_edgelist, self.B)
 
     def test_multiple_in(self):
         graphs = gs.utils.import_edgelist(self.root)
@@ -91,16 +98,16 @@ class TestImportEdgelist:
         B = np.zeros((20, 20))
         B[10:, 10:] = self.B
 
-        assert len(graphs) == 2
-        assert all(graph.shape == (20, 20) for graph in graphs)
-        assert np.allclose(graphs[0], A)
-        assert np.allclose(graphs[1], B)
+        self.assertEqual(len(graphs), 2)
+        self.assertTrue(all(graph.shape == (20, 20) for graph in graphs))
+        np.testing.assert_allclose(graphs[0], A)
+        np.testing.assert_allclose(graphs[1], B)
 
     def test_wrongtypein(self):
         path = 5
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             gs.utils.import_edgelist(path)
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             gs.utils.import_edgelist(None)
 
     def test_vertices(self):
@@ -110,15 +117,15 @@ class TestImportEdgelist:
         _, A_vertices = gs.utils.import_edgelist(self.A_path, return_vertices=True)
         _, B_vertices = gs.utils.import_edgelist(self.B_path, return_vertices=True)
 
-        assert np.allclose(expected_vertices_A, A_vertices)
-        assert np.allclose(expected_vertices_B, B_vertices)
+        np.testing.assert_allclose(expected_vertices_A, A_vertices)
+        np.testing.assert_allclose(expected_vertices_B, B_vertices)
 
     def test_no_graphs_found(self):
         path = str(self.root + "invalid_edgelist.edgelist")
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             gs.utils.import_edgelist(path)
 
     def test_bad_delimiter(self):
         delimiter = ","
-        with pytest.warns(UserWarning):
+        with self.assertWarns(UserWarning):
             graphs = gs.utils.import_edgelist(self.root, delimiter=delimiter)

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -2,8 +2,9 @@
 # Licensed under the MIT License.
 
 import unittest
-import numpy as np
+
 import networkx as nx
+import numpy as np
 from sklearn.metrics import pairwise_distances
 
 from graspologic.embed import AdjacencySpectralEmbed

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import pytest
 import unittest
 import numpy as np
 import networkx as nx
@@ -46,45 +45,45 @@ class TestLatentDistributionTest(unittest.TestCase):
         A2 = er_np(20, 0.3)
 
         # check test argument
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_distribution_test(A1, A2, test=0)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_distribution_test(A1, A2, test="foo")
         # check metric argument
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_distribution_test(A1, A2, metric=0)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_distribution_test(A1, A2, metric="some_kind_of_kernel")
         # check n_components argument
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_distribution_test(A1, A2, n_components=0.5)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_distribution_test(A1, A2, n_components=-100)
         # check n_bootstraps argument
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_distribution_test(A1, A2, n_bootstraps=0.5)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_distribution_test(A1, A2, n_bootstraps=-100)
         # check workers argument
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_distribution_test(A1, A2, workers=0.5)
             latent_distribution_test(A1, A2, workers="oops")
         # check size_correction argument
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_distribution_test(A1, A2, size_correction=0)
         # check pooled argument
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_distribution_test(A1, A2, pooled=0)
         # check align_type argument
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_distribution_test(A1, A2, align_type="foo")
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_distribution_test(A1, A2, align_type={"not a": "string"})
         # check align_kws argument
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_distribution_test(A1, A2, align_kws="foo")
         # check input_graph argument
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_distribution_test(A1, A2, input_graph="hello")
 
     def test_n_bootstraps(self):
@@ -159,7 +158,7 @@ class TestLatentDistributionTest(unittest.TestCase):
         A2 = er_np(100, 0.3)
         # some valid combinations of test and metric
         # # would love to do this, but currently FutureWarning breaks this
-        # with pytest.warns(None) as record:
+        # with self.assertWarns(None) as record:
         #     for test in self.tests.keys():
         #         ldt = LatentDistributionTest(test, self.tests[test])
         #         ldt.fit(A1, A2)
@@ -168,11 +167,11 @@ class TestLatentDistributionTest(unittest.TestCase):
         # assert len(record) == 0
         latent_distribution_test(A1, A2, test="hsic", metric="rbf")
         # some invalid combinations of test and metric
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_distribution_test(A1, A2, "hsic", "euclidean")
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_distribution_test(A1, A2, "dcorr", "gaussian")
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_distribution_test(A1, A2, "dcorr", "rbf")
 
     def test_bad_matrix_inputs(self):

--- a/tests/test_latentpositiontest.py
+++ b/tests/test_latentpositiontest.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import unittest
+
 import numpy as np
 
 from graspologic.inference import latent_position_test

--- a/tests/test_latentpositiontest.py
+++ b/tests/test_latentpositiontest.py
@@ -1,5 +1,7 @@
+# Copyright (c) Microsoft Corporation and contributors.
+# Licensed under the MIT License.
+
 import unittest
-import pytest
 import numpy as np
 
 from graspologic.inference import latent_position_test
@@ -26,23 +28,23 @@ class TestLatentPositionTest(unittest.TestCase):
         A1 = er_np(20, 0.3)
         A2 = er_np(20, 0.3)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_position_test(A1, A2, n_components=-100)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_position_test(A1, A2, test_case="oops")
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_position_test(A1, A2, n_bootstraps=-100)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_position_test(A1, A2, embedding="oops")
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_position_test(A1, A2, n_bootstraps=0.5)
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_position_test(A1, A2, n_components=0.5)
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_position_test(A1, A2, embedding=6)
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_position_test(A1, A2, test_case=6)
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_position_test(A1, A2, workers="oops")
 
     def test_n_bootstraps(self):
@@ -58,14 +60,14 @@ class TestLatentPositionTest(unittest.TestCase):
         A1 = er_np(20, 0.3)
         A2 = er_np(20, 0.3)
         A1[2, 0] = 1  # make asymmetric
-        with pytest.raises(NotImplementedError):  # TODO : remove when we implement
+        with self.assertRaises(NotImplementedError):  # TODO : remove when we implement
             latent_position_test(A1, A2)
 
         bad_matrix = [[1, 2]]
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             latent_position_test(bad_matrix, A2)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             latent_position_test(A1[:2, :2], A2)
 
     def test_rotation_norm(self):

--- a/tests/test_mase.py
+++ b/tests/test_mase.py
@@ -5,6 +5,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+
 from graspologic.cluster.gclust import GaussianCluster
 from graspologic.embed.mase import MultipleASE
 from graspologic.simulations.simulations import er_np, sbm

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -15,7 +15,6 @@ np.random.seed(1)
 
 
 class TestGMP(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls) -> None:
         cls.barycenter = GMP(gmp=False)
@@ -227,7 +226,7 @@ class TestGMP(unittest.TestCase):
         gm.fit(A, B, seeds_A=seeds_A, seeds_B=seeds_B)
 
         self.assertTrue((gm.perm_inds_ == pi_original).all())
-        self.assertEqual(gm.score_,  11156)
+        self.assertEqual(gm.score_, 11156)
 
     def test_sim(self):
         n = 150

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,13 +1,15 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import unittest
-import numpy as np
 import random
+import unittest
+
+import numpy as np
+
+from graspologic.align import SignFlips
+from graspologic.embed import AdjacencySpectralEmbed
 from graspologic.match import GraphMatch as GMP
 from graspologic.simulations import er_np, sbm_corr
-from graspologic.embed import AdjacencySpectralEmbed
-from graspologic.align import SignFlips
 
 np.random.seed(1)
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,9 +1,8 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import pytest
+import unittest
 import numpy as np
-import math
 import random
 from graspologic.match import GraphMatch as GMP
 from graspologic.simulations import er_np, sbm_corr
@@ -13,55 +12,56 @@ from graspologic.align import SignFlips
 np.random.seed(1)
 
 
-class TestGMP:
+class TestGMP(unittest.TestCase):
+
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls) -> None:
         cls.barycenter = GMP(gmp=False)
         cls.rand = GMP(n_init=100, init="rand", gmp=False)
         cls.barygm = GMP(gmp=True)
 
     def test_SGM_inputs(self):
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             GMP(n_init=-1.5)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP(init="random")
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             GMP(max_iter=-1.5)
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             GMP(shuffle_input="hey")
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             GMP(eps=-1)
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             GMP(gmp="hey")
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             GMP(padding=2)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP(padding="hey")
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP().fit(
                 np.random.random((3, 4)),
                 np.random.random((3, 4)),
                 np.arange(2),
                 np.arange(2),
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP().fit(
                 np.random.random((3, 4)),
                 np.random.random((3, 4)),
                 np.arange(2),
                 np.arange(2),
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP().fit(np.identity(3), np.identity(3), np.identity(3), np.arange(2))
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP().fit(np.identity(3), np.identity(3), np.arange(1), np.arange(2))
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP().fit(np.identity(3), np.identity(3), np.arange(5), np.arange(5))
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP().fit(
                 np.identity(3), np.identity(3), -1 * np.arange(2), -1 * np.arange(2)
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP().fit(
                 np.random.random((4, 4)),
                 np.random.random((4, 4)),
@@ -69,7 +69,7 @@ class TestGMP:
                 np.arange(2),
                 np.random.random((3, 4)),
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP().fit(
                 np.random.random((4, 4)),
                 np.random.random((4, 4)),
@@ -77,7 +77,7 @@ class TestGMP:
                 np.arange(2),
                 np.random.random((3, 3)),
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             GMP().fit(
                 np.random.random((3, 3)),
                 np.random.random((4, 4)),
@@ -133,33 +133,33 @@ class TestGMP:
         W2 = [pi[z] for z in W1]
         chr12c = self.barycenter.fit(A, B, W1, W2)
         score = chr12c.score_
-        assert 11156 <= score < 21000
+        self.assertTrue(11156 <= score < 21000)
 
         W1 = np.sort(random.sample(list(range(n)), n - 1))
         W2 = [pi[z] for z in W1]
         chr12c = self.barycenter.fit(A, B, W1, W2)
         score = chr12c.score_
-        assert 11156 == score
+        self.assertEqual(11156, score)
 
         W1 = np.array(range(n))
         W2 = pi
         chr12c = self.barycenter.fit(A, B, W1, W2)
         score = chr12c.score_
-        assert np.array_equal(chr12c.perm_inds_, pi)
-        assert 11156 == score
+        np.testing.assert_array_equal(chr12c.perm_inds_, pi)
+        self.assertTrue(11156, score)
 
         W1 = np.random.permutation(n)
         W2 = [pi[z] for z in W1]
         chr12c = self.barycenter.fit(A, B, W1, W2)
         score = chr12c.score_
-        assert np.array_equal(chr12c.perm_inds_, pi)
-        assert 11156 == score
+        np.testing.assert_array_equal(chr12c.perm_inds_, pi)
+        self.assertTrue(11156, score)
 
     def test_rand_SGM(self):
         A, B = self._get_AB()
         chr12c = self.rand.fit(A, B)
         score = chr12c.score_
-        assert 11156 <= score < 13500
+        self.assertTrue(11156 <= score < 13500)
 
         n = A.shape[0]
         pi = np.array([7, 5, 1, 3, 10, 4, 8, 6, 9, 11, 2, 12]) - [1] * n
@@ -167,14 +167,14 @@ class TestGMP:
         W2 = [pi[z] for z in W1]
         chr12c = self.rand.fit(A, B, W1, W2)
         score = chr12c.score_
-        assert 11156 <= score < 12500
+        self.assertTrue(11156 <= score < 12500)
 
     def test_parallel(self):
         A, B = self._get_AB()
         gmp = GMP(gmp=False, n_init=2, n_jobs=2)
         gmp.fit(A, B)
         score = gmp.score_
-        assert 11156 <= score < 13500
+        self.assertTrue(11156 <= score < 13500)
 
     def test_padding(self):
         n = 50
@@ -185,7 +185,7 @@ class TestGMP:
         gmp_adopted = GMP(padding="adopted")
         res = gmp_adopted.fit(G1, G2)
 
-        assert 0.95 <= (sum(res.perm_inds_ == np.arange(n)) / n)
+        self.assertTrue(0.95 <= (sum(res.perm_inds_ == np.arange(n)) / n))
 
     def test_custom_init(self):
         A, B = self._get_AB()
@@ -197,8 +197,8 @@ class TestGMP:
         gm = GMP(n_init=1, init=custom_init, max_iter=30, shuffle_input=True, gmp=False)
         gm.fit(A, B)
 
-        assert (gm.perm_inds_ == pi).all()
-        assert gm.score_ == 11156
+        self.assertTrue((gm.perm_inds_ == pi).all())
+        self.assertEqual(gm.score_, 11156)
         # we had thought about doing the test
         # `assert gm.n_iter_ == 1`
         # but note that GM doesn't necessarily converge in 1 iteration here
@@ -224,8 +224,8 @@ class TestGMP:
         gm = GMP(n_init=1, init=custom_init, max_iter=30, shuffle_input=True, gmp=False)
         gm.fit(A, B, seeds_A=seeds_A, seeds_B=seeds_B)
 
-        assert (gm.perm_inds_ == pi_original).all()
-        assert gm.score_ == 11156
+        self.assertTrue((gm.perm_inds_ == pi_original).all())
+        self.assertEqual(gm.score_,  11156)
 
     def test_sim(self):
         n = 150
@@ -248,7 +248,7 @@ class TestGMP:
         S = xh1 @ x2.T
         res = self.barygm.fit(A1, A2, S=S)
 
-        assert 0.7 <= (sum(res.perm_inds_ == np.arange(n)) / n)
+        self.assertTrue(0.7 <= (sum(res.perm_inds_ == np.arange(n)) / n))
 
         A1 = A1[:-1, :-1]
         xh1 = xh1[:-1, :]
@@ -256,4 +256,4 @@ class TestGMP:
 
         res = self.barygm.fit(A1, A2, S=S)
 
-        assert 0.6 <= (sum(res.perm_inds_ == np.arange(n)) / n)
+        self.assertTrue(0.6 <= (sum(res.perm_inds_ == np.arange(n)) / n))

--- a/tests/test_mds.py
+++ b/tests/test_mds.py
@@ -5,11 +5,15 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+from sklearn.utils.estimator_checks import check_estimator
 
 from graspologic.embed.mds import ClassicalMDS
 
 
 class TestMDS(unittest.TestCase):
+    def test_sklearn_conventions(self):
+        check_estimator(ClassicalMDS())
+
     def test_input(self):
         X = np.random.normal(0, 1, size=(10, 3))
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,20 +1,22 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import numpy as np
 import unittest
+
+import numpy as np
 from numpy.testing import assert_allclose
-from graspologic.models import (
-    EREstimator,
-    DCSBMEstimator,
-    SBMEstimator,
-    RDPGEstimator,
-    DCEREstimator,
-)
-from graspologic.simulations import er_np, sbm, sample_edges
-from graspologic.utils import cartesian_product, is_symmetric
-from sklearn.metrics import adjusted_rand_score
 from sklearn.exceptions import NotFittedError
+from sklearn.metrics import adjusted_rand_score
+
+from graspologic.models import (
+    DCEREstimator,
+    DCSBMEstimator,
+    EREstimator,
+    RDPGEstimator,
+    SBMEstimator,
+)
+from graspologic.simulations import er_np, sample_edges, sbm
+from graspologic.utils import cartesian_product, is_symmetric
 
 
 class TestER(unittest.TestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import pytest
 import numpy as np
+import unittest
 from numpy.testing import assert_allclose
 from graspologic.models import (
     EREstimator,
@@ -17,9 +17,9 @@ from sklearn.metrics import adjusted_rand_score
 from sklearn.exceptions import NotFittedError
 
 
-class TestER:
+class TestER(unittest.TestCase):
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls):
         np.random.seed(8888)
         cls.graph = er_np(1000, 0.5)
         cls.p = 0.5
@@ -31,26 +31,26 @@ class TestER:
     def test_ER_inputs(self):
         ere = EREstimator()
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             EREstimator(directed="hey")
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             EREstimator(loops=6)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             ere.fit(self.graph[:, :99])
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             ere.fit(self.graph[..., np.newaxis])
 
     def test_ER_fit(self):
         assert self.p_hat - self.p < 0.001
 
     def test_ER_sample(self):
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             self.estimator.sample(n_samples=-1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             self.estimator.sample(n_samples="nope")
         g = er_np(100, 0.5)
         estimator = EREstimator(directed=True, loops=False)
@@ -65,16 +65,16 @@ class TestER:
         estimator = EREstimator(directed=False)
         _test_score(estimator, p_mat, graph)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             estimator.score_samples(graph=er_np(500, 0.5))
 
     def test_ER_nparams(self):
         assert self.estimator._n_parameters() == 1
 
 
-class TestDCER:
+class TestDCER(unittest.TestCase):
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls) -> None:
         np.random.seed(8888)
         n = 1000
         p = 0.5
@@ -92,23 +92,23 @@ class TestDCER:
         estimator = DCEREstimator()
         _test_score(estimator, p_mat, graph)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             estimator.score_samples(graph=graph[1:500, 1:500])
 
     def test_DCER_inputs(self):
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             DCEREstimator(directed="hey")
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             DCEREstimator(loops=6)
 
         graph = er_np(100, 0.5)
         dcere = DCEREstimator()
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             dcere.fit(graph[:, :99])
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             dcere.fit(graph[..., np.newaxis])
 
     def test_DCER_fit(self):
@@ -124,14 +124,14 @@ class TestDCER:
         estimator = DCEREstimator(directed=True, loops=False)
         g = self.graph
         p_mat = self.p_mat
-        with pytest.raises(NotFittedError):
+        with self.assertRaises(NotFittedError):
             estimator.sample()
 
         estimator.fit(g)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             estimator.sample(n_samples=-1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             estimator.sample(n_samples="nope")
         B = 0.5
         dc = np.random.uniform(0.25, 0.75, size=100)
@@ -150,64 +150,63 @@ class TestDCER:
         assert e._n_parameters() == (n_verts + 1)
 
 
-class TestSBM:
-    @classmethod
-    def setup_class(cls):
+class TestSBM(unittest.TestCase):
+    def setUp(self) -> None:
         estimator = SBMEstimator(directed=True, loops=False)
         B = np.array([[0.9, 0.1], [0.1, 0.9]])
         g = sbm([50, 50], B, directed=True)
         labels = _n_to_labels([50, 50])
         p_mat = _block_to_full(B, labels, (100, 100))
         p_mat -= np.diag(np.diag(p_mat))
-        cls.estimator = estimator
-        cls.p_mat = p_mat
-        cls.graph = g
-        cls.labels = labels
+        self.estimator = estimator
+        self.p_mat = p_mat
+        self.graph = g
+        self.labels = labels
 
     def test_SBM_inputs(self):
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             SBMEstimator(directed="hey")
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             SBMEstimator(loops=6)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             SBMEstimator(n_components="XD")
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             SBMEstimator(n_components=-1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             SBMEstimator(min_comm="1")
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             SBMEstimator(min_comm=-1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             SBMEstimator(max_comm="ay")
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             SBMEstimator(max_comm=-1)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             SBMEstimator(min_comm=4, max_comm=2)
 
         graph = er_np(100, 0.5)
         bad_y = np.zeros(99)
         sbe = SBMEstimator()
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             sbe.fit(graph, y=bad_y)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             sbe.fit(graph[:, :99])
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             sbe.fit(graph[..., np.newaxis])
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             SBMEstimator(cluster_kws=1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             SBMEstimator(embed_kws=1)
 
     def test_SBM_fit_supervised(self):
@@ -248,14 +247,14 @@ class TestSBM:
         g = self.graph
         p_mat = self.p_mat
         labels = self.labels
-        with pytest.raises(NotFittedError):
+        with self.assertRaises(NotFittedError):
             estimator.sample()
 
         estimator.fit(g, y=labels)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             estimator.sample(n_samples=-1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             estimator.sample(n_samples="nope")
 
         _test_sample(estimator, p_mat)
@@ -271,7 +270,7 @@ class TestSBM:
         estimator = SBMEstimator(max_comm=4)
         _test_score(estimator, p_mat, graph)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             estimator.score_samples(graph=graph[1:100, 1:100])
 
     def test_SBM_nparams(self):
@@ -285,9 +284,9 @@ class TestSBM:
         assert e._n_parameters() == (1 + 3)
 
 
-class TestDCSBM:
+class TestDCSBM(unittest.TestCase):
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls) -> None:
         np.random.seed(8888)
         B = np.array(
             [
@@ -314,7 +313,7 @@ class TestDCSBM:
         estimator = DCSBMEstimator()
         _test_score(estimator, p_mat, graph)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             estimator.score_samples(graph=graph[1:100, 1:100])
 
     def test_DCSBM_fit_supervised(self):
@@ -326,49 +325,49 @@ class TestDCSBM:
         assert_allclose(dcsbe.p_mat_, p_mat, atol=0.1)
 
     def test_DCSBM_inputs(self):
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             DCSBMEstimator(directed="hey")
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             DCSBMEstimator(loops=6)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             DCSBMEstimator(n_components="XD")
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             DCSBMEstimator(n_components=-1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             DCSBMEstimator(min_comm="1")
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             DCSBMEstimator(min_comm=-1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             DCSBMEstimator(max_comm="ay")
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             DCSBMEstimator(max_comm=-1)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             DCSBMEstimator(min_comm=4, max_comm=2)
 
         graph = er_np(100, 0.5)
         bad_y = np.zeros(99)
         dcsbe = DCSBMEstimator()
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             dcsbe.fit(graph, y=bad_y)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             dcsbe.fit(graph[:, :99])
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             dcsbe.fit(graph[..., np.newaxis])
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             DCSBMEstimator(cluster_kws=1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             DCSBMEstimator(embed_kws=1)
 
     def test_DCSBM_fit_unsupervised(self):
@@ -400,14 +399,14 @@ class TestDCSBM:
         p_mat -= np.diag(np.diag(p_mat))
         g = sample_edges(p_mat, directed=True)
 
-        with pytest.raises(NotFittedError):
+        with self.assertRaises(NotFittedError):
             estimator.sample()
 
         estimator.fit(g, y=labels)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             estimator.sample(n_samples=-1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             estimator.sample(n_samples="nope")
         estimator.p_mat_ = p_mat
         _test_sample(estimator, p_mat, n_samples=1000, atol=0.1)
@@ -434,9 +433,8 @@ class TestDCSBM:
         assert e._n_parameters() == (n_verts + 10)
 
 
-class TestRDPG:
-    @classmethod
-    def setup_class(cls):
+class TestRDPG(unittest.TestCase):
+    def setUp(self) -> None:
         np.random.seed(8888)
         n_verts = 500
         point1 = np.array([0.1, 0.9])
@@ -447,34 +445,34 @@ class TestRDPG:
         p_mat = latent @ latent.T
         p_mat -= np.diag(np.diag(p_mat))
         g = sample_edges(p_mat)
-        cls.p_mat = p_mat
-        cls.graph = g
+        self.p_mat = p_mat
+        self.graph = g
 
     def test_RDPG_intputs(self):
         rdpge = RDPGEstimator()
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             RDPGEstimator(loops=6)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             rdpge.fit(self.graph[:, :99])
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             rdpge.fit(self.graph[..., np.newaxis])
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             RDPGEstimator(ase_kws=5)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             RDPGEstimator(diag_aug_weight="f")
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             RDPGEstimator(diag_aug_weight=-1)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             RDPGEstimator(plus_c_weight="F")
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             RDPGEstimator(plus_c_weight=-1)
 
     def test_RDPG_fit(self):
@@ -506,7 +504,7 @@ class TestRDPG:
         estimator = RDPGEstimator()
         _test_score(estimator, p_mat, graph)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             estimator.score_samples(graph=graph[1:100, 1:100])
 
     def test_RDPG_nparams(self):

--- a/tests/test_mug2vec.py
+++ b/tests/test_mug2vec.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import numpy as np
 import unittest
+
+import numpy as np
 
 from graspologic.cluster import GaussianCluster
 from graspologic.embed import mug2vec

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -48,7 +48,6 @@ def _test_pairplot_with_gmm_outputs(**kws):
 
 
 class TestPlot(unittest.TestCase):
-
     def test_common_inputs(self):
         X = er_np(100, 0.5)
         grid_labels = ["Test1"]
@@ -124,7 +123,6 @@ class TestPlot(unittest.TestCase):
         with self.assertRaises(TypeError):
             gridplot([X], hier_label_fontsize="f")
 
-
     def test_heatmap_inputs(self):
         """
         test parameter checks
@@ -154,7 +152,6 @@ class TestPlot(unittest.TestCase):
             cbar = 1
             heatmap(X, cbar=cbar)
 
-
     def test_heatmap_output(self):
         """
         simple function to see if plot is made without errors
@@ -163,13 +160,14 @@ class TestPlot(unittest.TestCase):
         xticklabels = ["Dimension {}".format(i) for i in range(10)]
         yticklabels = ["Dimension {}".format(i) for i in range(10)]
 
-        fig = heatmap(X, transform="log", xticklabels=xticklabels, yticklabels=yticklabels)
+        fig = heatmap(
+            X, transform="log", xticklabels=xticklabels, yticklabels=yticklabels
+        )
         fig = heatmap(X, transform="zero-boost")
         fig = heatmap(X, transform="simple-all")
         fig = heatmap(X, transform="simple-nonzero")
         fig = heatmap(X, transform="binarize")
         fig = heatmap(X, cmap="gist_rainbow")
-
 
     def test_gridplot_inputs(self):
         X = [er_np(10, 0.5)]
@@ -186,7 +184,6 @@ class TestPlot(unittest.TestCase):
             transform = "bad transform"
             gridplot(X, labels=labels, transform=transform)
 
-
     def test_gridplot_outputs(self):
         """
         simple function to see if plot is made without errors
@@ -196,7 +193,6 @@ class TestPlot(unittest.TestCase):
         fig = gridplot(X, labels)
         fig = gridplot(X, labels, transform="zero-boost")
         fig = gridplot(X, labels, "simple-all", title="Test", font_scale=0.9)
-
 
     def test_pairplot_inputs(self):
         X = np.random.rand(15, 3)
@@ -221,7 +217,6 @@ class TestPlot(unittest.TestCase):
         with self.assertRaises(KeyError):
             pairplot(X, col_names=["1", "2", "3"], variables=["A", "B"])
 
-
     def test_pairplot_outputs(self):
         X = np.random.rand(15, 3)
         Y = ["A"] * 5 + ["B"] * 5 + ["C"] * 5
@@ -231,20 +226,22 @@ class TestPlot(unittest.TestCase):
         fig = pairplot(X, Y)
         fig = pairplot(X, Y, col_names)
         fig = pairplot(
-            X, Y, col_names, title="Test", height=1.5, variables=["Feature1", "Feature2"]
+            X,
+            Y,
+            col_names,
+            title="Test",
+            height=1.5,
+            variables=["Feature1", "Feature2"],
         )
 
     def test_pairplot_with_gmm_inputs_type_full(self):
         _test_pairplot_with_gmm_inputs(self, covariance_type="full")
 
-
     def test_pairplot_with_gmm_inputs_type_diag(self):
         _test_pairplot_with_gmm_inputs(self, covariance_type="diag")
 
-
     def test_pairplot_with_gmm_inputs_type_tied(self):
         _test_pairplot_with_gmm_inputs(self, covariance_type="tied")
-
 
     def test_pairplot_with_gmm_inputs_type_spherical(self):
         _test_pairplot_with_gmm_inputs(self, covariance_type="spherical")
@@ -252,18 +249,14 @@ class TestPlot(unittest.TestCase):
     def test_pairplot_with_gmm_outputs_type_full(self):
         _test_pairplot_with_gmm_outputs(covariance_type="full")
 
-
     def test_pairplot_with_gmm_outputs_type_diag(self):
         _test_pairplot_with_gmm_outputs(covariance_type="diag")
-
 
     def test_pairplot_with_gmm_outputs_type_tied(self):
         _test_pairplot_with_gmm_outputs(covariance_type="tied")
 
-
     def test_pairplot_with_gmm_outputs_type_spherical(self):
         _test_pairplot_with_gmm_outputs(covariance_type="spherical")
-
 
     def test_sort_inds(self):
         B = np.array(

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import numpy as np
-import pytest
+import unittest
 from sklearn.mixture import GaussianMixture
 from graspologic.plot.plot import (
     heatmap,
@@ -14,221 +14,19 @@ from graspologic.plot.plot import (
 from graspologic.simulations.simulations import er_np, sbm
 
 
-def test_common_inputs():
-    X = er_np(100, 0.5)
-    grid_labels = ["Test1"]
-
-    # test figsize
-    with pytest.raises(TypeError):
-        figsize = "bad figsize"
-        heatmap(X, figsize=figsize)
-
-    # test height
-    height = "1"
-    with pytest.raises(TypeError):
-        gridplot([X], grid_labels, height=height)
-    with pytest.raises(TypeError):
-        pairplot(X, height=height)
-
-    # test title
-    title = 1
-    with pytest.raises(TypeError):
-        heatmap(X, title=title)
-    with pytest.raises(TypeError):
-        gridplot([X], grid_labels, title=title)
-    with pytest.raises(TypeError):
-        pairplot(X, title=title)
-
-    # test context
-    context = 123
-    with pytest.raises(TypeError):
-        heatmap(X, context=context)
-    with pytest.raises(TypeError):
-        gridplot([X], grid_labels, context=context)
-    with pytest.raises(TypeError):
-        pairplot(X, context=context)
-
-    context = "journal"
-    with pytest.raises(ValueError):
-        heatmap(X, context=context)
-    with pytest.raises(ValueError):
-        gridplot([X], grid_labels, context=context)
-    with pytest.raises(ValueError):
-        pairplot(X, context=context)
-
-    # test font scales
-    font_scales = ["1", []]
-    for font_scale in font_scales:
-        with pytest.raises(TypeError):
-            heatmap(X, font_scale=font_scale)
-        with pytest.raises(TypeError):
-            gridplot([X], grid_labels, font_scale=font_scale)
-        with pytest.raises(TypeError):
-            pairplot(X, cont_scale=font_scale)
-
-    # ticklabels
-    with pytest.raises(TypeError):
-        xticklabels = "labels"
-        yticklabels = "labels"
-        heatmap(X, xticklabels=xticklabels, yticklabels=yticklabels)
-
-    with pytest.raises(ValueError):
-        xticklabels = ["{}".format(i) for i in range(5)]
-        yticklabels = ["{}".format(i) for i in range(5)]
-        heatmap(X, xticklabels=xticklabels, yticklabels=yticklabels)
-
-    with pytest.raises(TypeError):
-        heatmap(X, title_pad="f")
-
-    with pytest.raises(TypeError):
-        gridplot([X], title_pad="f")
-
-    with pytest.raises(TypeError):
-        heatmap(X, hier_label_fontsize="f")
-
-    with pytest.raises(TypeError):
-        gridplot([X], hier_label_fontsize="f")
-
-
-def test_heatmap_inputs():
-    """
-    test parameter checks
-    """
-    X = np.random.rand(10, 10)
-
-    with pytest.raises(TypeError):
-        heatmap(X="input")
-
-    # transform
-    with pytest.raises(ValueError):
-        transform = "bad transform"
-        heatmap(X, transform=transform)
-
-    # cmap
-    with pytest.raises(TypeError):
-        cmap = 123
-        heatmap(X, cmap=cmap)
-
-    # center
-    with pytest.raises(TypeError):
-        center = "center"
-        heatmap(X, center=center)
-
-    # cbar
-    with pytest.raises(TypeError):
-        cbar = 1
-        heatmap(X, cbar=cbar)
-
-
-def test_heatmap_output():
-    """
-    simple function to see if plot is made without errors
-    """
-    X = er_np(10, 0.5)
-    xticklabels = ["Dimension {}".format(i) for i in range(10)]
-    yticklabels = ["Dimension {}".format(i) for i in range(10)]
-
-    fig = heatmap(X, transform="log", xticklabels=xticklabels, yticklabels=yticklabels)
-    fig = heatmap(X, transform="zero-boost")
-    fig = heatmap(X, transform="simple-all")
-    fig = heatmap(X, transform="simple-nonzero")
-    fig = heatmap(X, transform="binarize")
-    fig = heatmap(X, cmap="gist_rainbow")
-
-
-def test_gridplot_inputs():
-    X = [er_np(10, 0.5)]
-    labels = ["ER(10, 0.5)"]
-
-    with pytest.raises(TypeError):
-        gridplot(X="input", labels=labels)
-
-    with pytest.raises(ValueError):
-        gridplot(X, labels=["a", "b"])
-
-    # transform
-    with pytest.raises(ValueError):
-        transform = "bad transform"
-        gridplot(X, labels=labels, transform=transform)
-
-
-def test_gridplot_outputs():
-    """
-    simple function to see if plot is made without errors
-    """
-    X = [er_np(10, 0.5) for _ in range(2)]
-    labels = ["Random A", "Random B"]
-    fig = gridplot(X, labels)
-    fig = gridplot(X, labels, transform="zero-boost")
-    fig = gridplot(X, labels, "simple-all", title="Test", font_scale=0.9)
-
-
-def test_pairplot_inputs():
-    X = np.random.rand(15, 3)
-    Y = ["A"] * 5 + ["B"] * 5 + ["C"] * 5
-
-    # test data
-    with pytest.raises(TypeError):
-        pairplot(X="test")
-
-    with pytest.raises(ValueError):
-        pairplot(X=X, labels=["A"])
-
-    with pytest.raises(TypeError):
-        pairplot(X, col_names="A")
-
-    with pytest.raises(ValueError):
-        pairplot(X, col_names=["1", "2"])
-
-    with pytest.raises(ValueError):
-        pairplot(X, col_names=["1", "2", "3"], variables=[1, 2, 3, 4])
-
-    with pytest.raises(KeyError):
-        pairplot(X, col_names=["1", "2", "3"], variables=["A", "B"])
-
-
-def test_pairplot_outputs():
-    X = np.random.rand(15, 3)
-    Y = ["A"] * 5 + ["B"] * 5 + ["C"] * 5
-    col_names = ["Feature1", "Feature2", "Feature3"]
-
-    fig = pairplot(X)
-    fig = pairplot(X, Y)
-    fig = pairplot(X, Y, col_names)
-    fig = pairplot(
-        X, Y, col_names, title="Test", height=1.5, variables=["Feature1", "Feature2"]
-    )
-
-
-def _test_pairplot_with_gmm_inputs(**kws):
+def _test_pairplot_with_gmm_inputs(caller: unittest.TestCase, **kws):
     X = np.random.rand(15, 3)
     gmm = GaussianMixture(n_components=3, **kws).fit(X)
     labels = ["A"] * 5 + ["B"] * 5 + ["C"] * 5
     # test data
-    with pytest.raises(ValueError):
+    with caller.assertRaises(ValueError):
         pairplot_with_gmm(X="test", gmm=gmm)
 
-    with pytest.raises(ValueError):
+    with caller.assertRaises(ValueError):
         pairplot_with_gmm(X=X, gmm=gmm, labels=["A"])
 
-    with pytest.raises(NameError):
+    with caller.assertRaises(NameError):
         pairplot_with_gmm(X, gmm=None)
-
-
-def test_pairplot_with_gmm_inputs_type_full():
-    _test_pairplot_with_gmm_inputs(covariance_type="full")
-
-
-def test_pairplot_with_gmm_inputs_type_diag():
-    _test_pairplot_with_gmm_inputs(covariance_type="diag")
-
-
-def test_pairplot_with_gmm_inputs_type_tied():
-    _test_pairplot_with_gmm_inputs(covariance_type="tied")
-
-
-def test_pairplot_with_gmm_inputs_type_spherical():
-    _test_pairplot_with_gmm_inputs(covariance_type="spherical")
 
 
 def _test_pairplot_with_gmm_outputs(**kws):
@@ -247,68 +45,270 @@ def _test_pairplot_with_gmm_outputs(**kws):
     )
 
 
-def test_pairplot_with_gmm_outputs_type_full():
-    _test_pairplot_with_gmm_outputs(covariance_type="full")
+class TestPlot(unittest.TestCase):
+
+    def test_common_inputs(self):
+        X = er_np(100, 0.5)
+        grid_labels = ["Test1"]
+
+        # test figsize
+        with self.assertRaises(TypeError):
+            figsize = "bad figsize"
+            heatmap(X, figsize=figsize)
+
+        # test height
+        height = "1"
+        with self.assertRaises(TypeError):
+            gridplot([X], grid_labels, height=height)
+        with self.assertRaises(TypeError):
+            pairplot(X, height=height)
+
+        # test title
+        title = 1
+        with self.assertRaises(TypeError):
+            heatmap(X, title=title)
+        with self.assertRaises(TypeError):
+            gridplot([X], grid_labels, title=title)
+        with self.assertRaises(TypeError):
+            pairplot(X, title=title)
+
+        # test context
+        context = 123
+        with self.assertRaises(TypeError):
+            heatmap(X, context=context)
+        with self.assertRaises(TypeError):
+            gridplot([X], grid_labels, context=context)
+        with self.assertRaises(TypeError):
+            pairplot(X, context=context)
+
+        context = "journal"
+        with self.assertRaises(ValueError):
+            heatmap(X, context=context)
+        with self.assertRaises(ValueError):
+            gridplot([X], grid_labels, context=context)
+        with self.assertRaises(ValueError):
+            pairplot(X, context=context)
+
+        # test font scales
+        font_scales = ["1", []]
+        for font_scale in font_scales:
+            with self.assertRaises(TypeError):
+                heatmap(X, font_scale=font_scale)
+            with self.assertRaises(TypeError):
+                gridplot([X], grid_labels, font_scale=font_scale)
+            with self.assertRaises(TypeError):
+                pairplot(X, cont_scale=font_scale)
+
+        # ticklabels
+        with self.assertRaises(TypeError):
+            xticklabels = "labels"
+            yticklabels = "labels"
+            heatmap(X, xticklabels=xticklabels, yticklabels=yticklabels)
+
+        with self.assertRaises(ValueError):
+            xticklabels = ["{}".format(i) for i in range(5)]
+            yticklabels = ["{}".format(i) for i in range(5)]
+            heatmap(X, xticklabels=xticklabels, yticklabels=yticklabels)
+
+        with self.assertRaises(TypeError):
+            heatmap(X, title_pad="f")
+
+        with self.assertRaises(TypeError):
+            gridplot([X], title_pad="f")
+
+        with self.assertRaises(TypeError):
+            heatmap(X, hier_label_fontsize="f")
+
+        with self.assertRaises(TypeError):
+            gridplot([X], hier_label_fontsize="f")
 
 
-def test_pairplot_with_gmm_outputs_type_diag():
-    _test_pairplot_with_gmm_outputs(covariance_type="diag")
+    def test_heatmap_inputs(self):
+        """
+        test parameter checks
+        """
+        X = np.random.rand(10, 10)
+
+        with self.assertRaises(TypeError):
+            heatmap(X="input")
+
+        # transform
+        with self.assertRaises(ValueError):
+            transform = "bad transform"
+            heatmap(X, transform=transform)
+
+        # cmap
+        with self.assertRaises(TypeError):
+            cmap = 123
+            heatmap(X, cmap=cmap)
+
+        # center
+        with self.assertRaises(TypeError):
+            center = "center"
+            heatmap(X, center=center)
+
+        # cbar
+        with self.assertRaises(TypeError):
+            cbar = 1
+            heatmap(X, cbar=cbar)
 
 
-def test_pairplot_with_gmm_outputs_type_tied():
-    _test_pairplot_with_gmm_outputs(covariance_type="tied")
+    def test_heatmap_output(self):
+        """
+        simple function to see if plot is made without errors
+        """
+        X = er_np(10, 0.5)
+        xticklabels = ["Dimension {}".format(i) for i in range(10)]
+        yticklabels = ["Dimension {}".format(i) for i in range(10)]
+
+        fig = heatmap(X, transform="log", xticklabels=xticklabels, yticklabels=yticklabels)
+        fig = heatmap(X, transform="zero-boost")
+        fig = heatmap(X, transform="simple-all")
+        fig = heatmap(X, transform="simple-nonzero")
+        fig = heatmap(X, transform="binarize")
+        fig = heatmap(X, cmap="gist_rainbow")
 
 
-def test_pairplot_with_gmm_outputs_type_spherical():
-    _test_pairplot_with_gmm_outputs(covariance_type="spherical")
+    def test_gridplot_inputs(self):
+        X = [er_np(10, 0.5)]
+        labels = ["ER(10, 0.5)"]
+
+        with self.assertRaises(TypeError):
+            gridplot(X="input", labels=labels)
+
+        with self.assertRaises(ValueError):
+            gridplot(X, labels=["a", "b"])
+
+        # transform
+        with self.assertRaises(ValueError):
+            transform = "bad transform"
+            gridplot(X, labels=labels, transform=transform)
 
 
-def test_sort_inds():
-    B = np.array(
-        [
-            [0, 0.2, 0.1, 0.1, 0.1],
-            [0.2, 0.8, 0.1, 0.3, 0.1],
-            [0.15, 0.1, 0, 0.05, 0.1],
-            [0.1, 0.1, 0.2, 1, 0.1],
-            [0.1, 0.2, 0.1, 0.1, 0.8],
-        ]
-    )
+    def test_gridplot_outputs(self):
+        """
+        simple function to see if plot is made without errors
+        """
+        X = [er_np(10, 0.5) for _ in range(2)]
+        labels = ["Random A", "Random B"]
+        fig = gridplot(X, labels)
+        fig = gridplot(X, labels, transform="zero-boost")
+        fig = gridplot(X, labels, "simple-all", title="Test", font_scale=0.9)
 
-    g = sbm([10, 30, 50, 25, 25], B, directed=True)
-    degrees = g.sum(axis=0) + g.sum(axis=1)
-    degree_sort_inds = np.argsort(degrees)
-    labels2 = 40 * ["0"] + 100 * ["1"]
-    labels1 = 10 * ["d"] + 30 * ["c"] + 50 * ["d"] + 25 * ["e"] + 25 * ["c"]
-    labels1 = np.array(labels1)
-    labels2 = np.array(labels2)
-    sorted_inds = _sort_inds(g, labels1, labels2, True)
-    # sort outer blocks first if given, sort by num verts in the block
-    # for inner hier, sort by num verts for that category across the entire graph
-    # ie if there are multiple inner hier across different outer blocks, sort
-    # by prevalence in the entire graph, not within block
-    # this is to make the ordering within outer block consistent
-    # within a block, sort by degree
 
-    # outer block order should thus be: 1, 0
-    # inner block order should thus be: d, c, e
+    def test_pairplot_inputs(self):
+        X = np.random.rand(15, 3)
+        Y = ["A"] * 5 + ["B"] * 5 + ["C"] * 5
 
-    # show that outer blocks are sorted correctly
-    labels2 = labels2[sorted_inds]
-    assert np.all(labels2[:100] == "1")
-    assert np.all(labels2[100:] == "0")
+        # test data
+        with self.assertRaises(TypeError):
+            pairplot(X="test")
 
-    # show that inner blocks are sorted correctly
-    labels1 = labels1[sorted_inds]
-    assert np.all(labels1[:50] == "d")
-    assert np.all(labels1[50:75] == "c")
-    assert np.all(labels1[75:100] == "e")
-    assert np.all(labels1[100:110] == "d")
-    assert np.all(labels1[110:] == "c")
+        with self.assertRaises(ValueError):
+            pairplot(X=X, labels=["A"])
 
-    # show that within block, everything is in descending degree order
-    degrees = degrees[sorted_inds]
-    assert np.all(np.diff(degrees[:50]) <= 0)
-    assert np.all(np.diff(degrees[50:75]) <= 0)
-    assert np.all(np.diff(degrees[75:100]) <= 0)
-    assert np.all(np.diff(degrees[100:110]) <= 0)
-    assert np.all(np.diff(degrees[110:]) <= 0)
+        with self.assertRaises(TypeError):
+            pairplot(X, col_names="A")
+
+        with self.assertRaises(ValueError):
+            pairplot(X, col_names=["1", "2"])
+
+        with self.assertRaises(ValueError):
+            pairplot(X, col_names=["1", "2", "3"], variables=[1, 2, 3, 4])
+
+        with self.assertRaises(KeyError):
+            pairplot(X, col_names=["1", "2", "3"], variables=["A", "B"])
+
+
+    def test_pairplot_outputs(self):
+        X = np.random.rand(15, 3)
+        Y = ["A"] * 5 + ["B"] * 5 + ["C"] * 5
+        col_names = ["Feature1", "Feature2", "Feature3"]
+
+        fig = pairplot(X)
+        fig = pairplot(X, Y)
+        fig = pairplot(X, Y, col_names)
+        fig = pairplot(
+            X, Y, col_names, title="Test", height=1.5, variables=["Feature1", "Feature2"]
+        )
+
+    def test_pairplot_with_gmm_inputs_type_full(self):
+        _test_pairplot_with_gmm_inputs(self, covariance_type="full")
+
+
+    def test_pairplot_with_gmm_inputs_type_diag(self):
+        _test_pairplot_with_gmm_inputs(self, covariance_type="diag")
+
+
+    def test_pairplot_with_gmm_inputs_type_tied(self):
+        _test_pairplot_with_gmm_inputs(self, covariance_type="tied")
+
+
+    def test_pairplot_with_gmm_inputs_type_spherical(self):
+        _test_pairplot_with_gmm_inputs(self, covariance_type="spherical")
+
+    def test_pairplot_with_gmm_outputs_type_full(self):
+        _test_pairplot_with_gmm_outputs(covariance_type="full")
+
+
+    def test_pairplot_with_gmm_outputs_type_diag(self):
+        _test_pairplot_with_gmm_outputs(covariance_type="diag")
+
+
+    def test_pairplot_with_gmm_outputs_type_tied(self):
+        _test_pairplot_with_gmm_outputs(covariance_type="tied")
+
+
+    def test_pairplot_with_gmm_outputs_type_spherical(self):
+        _test_pairplot_with_gmm_outputs(covariance_type="spherical")
+
+
+    def test_sort_inds(self):
+        B = np.array(
+            [
+                [0, 0.2, 0.1, 0.1, 0.1],
+                [0.2, 0.8, 0.1, 0.3, 0.1],
+                [0.15, 0.1, 0, 0.05, 0.1],
+                [0.1, 0.1, 0.2, 1, 0.1],
+                [0.1, 0.2, 0.1, 0.1, 0.8],
+            ]
+        )
+
+        g = sbm([10, 30, 50, 25, 25], B, directed=True)
+        degrees = g.sum(axis=0) + g.sum(axis=1)
+        degree_sort_inds = np.argsort(degrees)
+        labels2 = 40 * ["0"] + 100 * ["1"]
+        labels1 = 10 * ["d"] + 30 * ["c"] + 50 * ["d"] + 25 * ["e"] + 25 * ["c"]
+        labels1 = np.array(labels1)
+        labels2 = np.array(labels2)
+        sorted_inds = _sort_inds(g, labels1, labels2, True)
+        # sort outer blocks first if given, sort by num verts in the block
+        # for inner hier, sort by num verts for that category across the entire graph
+        # ie if there are multiple inner hier across different outer blocks, sort
+        # by prevalence in the entire graph, not within block
+        # this is to make the ordering within outer block consistent
+        # within a block, sort by degree
+
+        # outer block order should thus be: 1, 0
+        # inner block order should thus be: d, c, e
+
+        # show that outer blocks are sorted correctly
+        labels2 = labels2[sorted_inds]
+        self.assertTrue(np.all(labels2[:100] == "1"))
+        self.assertTrue(np.all(labels2[100:] == "0"))
+
+        # show that inner blocks are sorted correctly
+        labels1 = labels1[sorted_inds]
+        self.assertTrue(np.all(labels1[:50] == "d"))
+        self.assertTrue(np.all(labels1[50:75] == "c"))
+        self.assertTrue(np.all(labels1[75:100] == "e"))
+        self.assertTrue(np.all(labels1[100:110] == "d"))
+        self.assertTrue(np.all(labels1[110:] == "c"))
+
+        # show that within block, everything is in descending degree order
+        degrees = degrees[sorted_inds]
+        self.assertTrue(np.all(np.diff(degrees[:50]) <= 0))
+        self.assertTrue(np.all(np.diff(degrees[50:75]) <= 0))
+        self.assertTrue(np.all(np.diff(degrees[75:100]) <= 0))
+        self.assertTrue(np.all(np.diff(degrees[100:110]) <= 0))
+        self.assertTrue(np.all(np.diff(degrees[110:]) <= 0))

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,14 +1,16 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import numpy as np
 import unittest
+
+import numpy as np
 from sklearn.mixture import GaussianMixture
+
 from graspologic.plot.plot import (
-    heatmap,
-    gridplot,
-    pairplot,
     _sort_inds,
+    gridplot,
+    heatmap,
+    pairplot,
     pairplot_with_gmm,
 )
 from graspologic.simulations.simulations import er_np, sbm

--- a/tests/test_plot_matrix.py
+++ b/tests/test_plot_matrix.py
@@ -3,193 +3,195 @@
 
 import numpy as np
 import pandas as pd
-import pytest
+import unittest
 from graspologic.plot.plot_matrix import adjplot, matrixplot
 from graspologic.simulations.simulations import er_np
-from scipy.sparse import csr, csr_matrix
+from scipy.sparse import csr_matrix
 
 
-def test_adjplot_inputs():
-    X = er_np(100, 0.5)
-    meta = pd.DataFrame(
-        {
-            "hemisphere": np.random.randint(2, size=100),
-            "region": np.random.randint(2, size=100),
-            "cell_size": np.random.randint(10, size=100),
-        }
-    )
+class TestPlotMatrix(unittest.TestCase):
 
-    # test matrix
-    with pytest.raises(TypeError):
-        adjplot(data="input", meta=meta)
-    with pytest.raises(ValueError):
-        adjplot(data=np.zeros((2, 2, 2)), meta=meta)
-
-    # test meta
-    with pytest.raises(ValueError):
-        bad_meta = pd.DataFrame(
+    def test_adjplot_inputs(self):
+        X = er_np(100, 0.5)
+        meta = pd.DataFrame(
             {
-                "hemisphere": np.random.randint(2, size=1),
-                "region": np.random.randint(2, size=1),
-                "cell_size": np.random.randint(10, size=1),
+                "hemisphere": np.random.randint(2, size=100),
+                "region": np.random.randint(2, size=100),
+                "cell_size": np.random.randint(10, size=100),
             }
         )
-        adjplot(X, meta=bad_meta)
-
-    # test plot type
-    with pytest.raises(ValueError):
-        adjplot(X, plot_type="bad plottype")
-
-    # test sorting_kws
-    with pytest.raises(TypeError):
-        adjplot(X, meta=meta, group=123)
-    with pytest.raises(TypeError):
-        adjplot(X, meta=meta, group_order=123)
-    with pytest.raises(TypeError):
-        adjplot(X, meta=meta, item_order=123)
-    with pytest.raises(TypeError):
-        adjplot(X, meta=meta, color=123)
-    with pytest.raises(ValueError):
-        adjplot(X, meta=meta, group="bad value")
-    with pytest.raises(ValueError):
-        adjplot(X, meta=meta, group_order="bad value")
-    with pytest.raises(ValueError):
-        adjplot(X, meta=meta, item_order="bad value")
-    with pytest.raises(ValueError):
-        adjplot(X, meta=meta, color="bad value")
-
-
-def test_adjplot_output():
-    """
-    simple function to see if plot is made without errors
-    """
-    X = er_np(10, 0.5)
-    meta = pd.DataFrame(
-        {
-            "hemisphere": np.random.randint(2, size=10),
-            "region": np.random.randint(2, size=10),
-            "cell_size": np.random.randint(10, size=10),
-        }
-    )
-    ax = adjplot(X, meta=meta)
-    ax = adjplot(X, meta=meta, group="hemisphere")
-    ax = adjplot(X, meta=meta, group="hemisphere", group_order="size")
-    ax = adjplot(X, meta=meta, group="hemisphere", item_order="cell_size")
-
-
-def test_adjplot_sparse():
-    X = er_np(10, 0.5)
-    adjplot(csr_matrix(X), plot_type="scattermap")
-
-
-def test_matrix_inputs():
-    X = er_np(100, 0.5)
-    meta = pd.DataFrame(
-        {
-            "hemisphere": np.random.randint(2, size=100),
-            "region": np.random.randint(2, size=100),
-            "cell_size": np.random.randint(10, size=100),
-        }
-    )
-
-    # test matrix
-    with pytest.raises(TypeError):
-        matrixplot(data="input", col_meta=meta, row_meta=meta)
-    with pytest.raises(ValueError):
-        matrixplot(data=np.zeros((2, 2, 2)), col_meta=meta, row_meta=meta)
-
-    # test meta
-    with pytest.raises(ValueError):
-        bad_meta = pd.DataFrame(
+    
+        # test matrix
+        with self.assertRaises(TypeError):
+            adjplot(data="input", meta=meta)
+        with self.assertRaises(ValueError):
+            adjplot(data=np.zeros((2, 2, 2)), meta=meta)
+    
+        # test meta
+        with self.assertRaises(ValueError):
+            bad_meta = pd.DataFrame(
+                {
+                    "hemisphere": np.random.randint(2, size=1),
+                    "region": np.random.randint(2, size=1),
+                    "cell_size": np.random.randint(10, size=1),
+                }
+            )
+            adjplot(X, meta=bad_meta)
+    
+        # test plot type
+        with self.assertRaises(ValueError):
+            adjplot(X, plot_type="bad plottype")
+    
+        # test sorting_kws
+        with self.assertRaises(TypeError):
+            adjplot(X, meta=meta, group=123)
+        with self.assertRaises(TypeError):
+            adjplot(X, meta=meta, group_order=123)
+        with self.assertRaises(TypeError):
+            adjplot(X, meta=meta, item_order=123)
+        with self.assertRaises(TypeError):
+            adjplot(X, meta=meta, color=123)
+        with self.assertRaises(ValueError):
+            adjplot(X, meta=meta, group="bad value")
+        with self.assertRaises(ValueError):
+            adjplot(X, meta=meta, group_order="bad value")
+        with self.assertRaises(ValueError):
+            adjplot(X, meta=meta, item_order="bad value")
+        with self.assertRaises(ValueError):
+            adjplot(X, meta=meta, color="bad value")
+    
+    
+    def test_adjplot_output(self):
+        """
+        simple function to see if plot is made without errors
+        """
+        X = er_np(10, 0.5)
+        meta = pd.DataFrame(
             {
-                "hemisphere": np.random.randint(2, size=1),
-                "region": np.random.randint(2, size=1),
-                "cell_size": np.random.randint(10, size=1),
+                "hemisphere": np.random.randint(2, size=10),
+                "region": np.random.randint(2, size=10),
+                "cell_size": np.random.randint(10, size=10),
             }
         )
-        matrixplot(X, col_meta=bad_meta, row_meta=bad_meta)
-
-    # test plot type
-    with pytest.raises(ValueError):
-        matrixplot(X, plot_type="bad plottype", col_meta=meta, row_meta=meta)
-
-    # test sorting_kws
-    with pytest.raises(TypeError):
-        matrixplot(X, col_meta=meta, row_meta=meta, col_group=123, row_group=123)
-    with pytest.raises(TypeError):
-        matrixplot(
-            X, col_meta=meta, col_group_order=123, row_meta=meta, row_group_order=123
+        ax = adjplot(X, meta=meta)
+        ax = adjplot(X, meta=meta, group="hemisphere")
+        ax = adjplot(X, meta=meta, group="hemisphere", group_order="size")
+        ax = adjplot(X, meta=meta, group="hemisphere", item_order="cell_size")
+    
+    
+    def test_adjplot_sparse(self):
+        X = er_np(10, 0.5)
+        adjplot(csr_matrix(X), plot_type="scattermap")
+    
+    
+    def test_matrix_inputs(self):
+        X = er_np(100, 0.5)
+        meta = pd.DataFrame(
+            {
+                "hemisphere": np.random.randint(2, size=100),
+                "region": np.random.randint(2, size=100),
+                "cell_size": np.random.randint(10, size=100),
+            }
         )
-    with pytest.raises(TypeError):
-        matrixplot(
-            X, col_meta=meta, col_item_order=123, row_meta=meta, row_item_order=123
+    
+        # test matrix
+        with self.assertRaises(TypeError):
+            matrixplot(data="input", col_meta=meta, row_meta=meta)
+        with self.assertRaises(ValueError):
+            matrixplot(data=np.zeros((2, 2, 2)), col_meta=meta, row_meta=meta)
+    
+        # test meta
+        with self.assertRaises(ValueError):
+            bad_meta = pd.DataFrame(
+                {
+                    "hemisphere": np.random.randint(2, size=1),
+                    "region": np.random.randint(2, size=1),
+                    "cell_size": np.random.randint(10, size=1),
+                }
+            )
+            matrixplot(X, col_meta=bad_meta, row_meta=bad_meta)
+    
+        # test plot type
+        with self.assertRaises(ValueError):
+            matrixplot(X, plot_type="bad plottype", col_meta=meta, row_meta=meta)
+    
+        # test sorting_kws
+        with self.assertRaises(TypeError):
+            matrixplot(X, col_meta=meta, row_meta=meta, col_group=123, row_group=123)
+        with self.assertRaises(TypeError):
+            matrixplot(
+                X, col_meta=meta, col_group_order=123, row_meta=meta, row_group_order=123
+            )
+        with self.assertRaises(TypeError):
+            matrixplot(
+                X, col_meta=meta, col_item_order=123, row_meta=meta, row_item_order=123
+            )
+        with self.assertRaises(TypeError):
+            matrixplot(X, col_meta=meta, col_color=123, row_meta=meta, row_color=123)
+        with self.assertRaises(ValueError):
+            matrixplot(
+                X,
+                col_meta=meta,
+                col_group="bad value",
+                row_meta=meta,
+                row_group="bad value",
+            )
+        with self.assertRaises(ValueError):
+            matrixplot(
+                X,
+                col_meta=meta,
+                col_group_order="bad value",
+                row_meta=meta,
+                row_group_order="bad value",
+            )
+        with self.assertRaises(ValueError):
+            matrixplot(
+                X,
+                col_meta=meta,
+                col_item_order="bad value",
+                row_meta=meta,
+                row_item_order="bad value",
+            )
+        with self.assertRaises(ValueError):
+            matrixplot(
+                X,
+                col_meta=meta,
+                col_color="bad value",
+                row_meta=meta,
+                row_color="bad value",
+            )
+    
+    
+    def test_matrix_output(self):
+        """
+        simple function to see if plot is made without errors
+        """
+        X = er_np(10, 0.5)
+        meta = pd.DataFrame(
+            {
+                "hemisphere": np.random.randint(2, size=10),
+                "region": np.random.randint(2, size=10),
+                "cell_size": np.random.randint(10, size=10),
+            }
         )
-    with pytest.raises(TypeError):
-        matrixplot(X, col_meta=meta, col_color=123, row_meta=meta, row_color=123)
-    with pytest.raises(ValueError):
-        matrixplot(
+        ax = matrixplot(X, col_meta=meta, row_meta=meta)
+        ax = matrixplot(X, col_meta=meta, row_meta=meta, row_group="hemisphere")
+        ax = matrixplot(
             X,
             col_meta=meta,
-            col_group="bad value",
             row_meta=meta,
-            row_group="bad value",
+            row_group="hemisphere",
+            col_group_order="size",
         )
-    with pytest.raises(ValueError):
-        matrixplot(
+        ax = matrixplot(
             X,
             col_meta=meta,
-            col_group_order="bad value",
             row_meta=meta,
-            row_group_order="bad value",
+            col_group="hemisphere",
+            row_item_order="cell_size",
         )
-    with pytest.raises(ValueError):
-        matrixplot(
-            X,
-            col_meta=meta,
-            col_item_order="bad value",
-            row_meta=meta,
-            row_item_order="bad value",
-        )
-    with pytest.raises(ValueError):
-        matrixplot(
-            X,
-            col_meta=meta,
-            col_color="bad value",
-            row_meta=meta,
-            row_color="bad value",
-        )
-
-
-def test_matrix_output():
-    """
-    simple function to see if plot is made without errors
-    """
-    X = er_np(10, 0.5)
-    meta = pd.DataFrame(
-        {
-            "hemisphere": np.random.randint(2, size=10),
-            "region": np.random.randint(2, size=10),
-            "cell_size": np.random.randint(10, size=10),
-        }
-    )
-    ax = matrixplot(X, col_meta=meta, row_meta=meta)
-    ax = matrixplot(X, col_meta=meta, row_meta=meta, row_group="hemisphere")
-    ax = matrixplot(
-        X,
-        col_meta=meta,
-        row_meta=meta,
-        row_group="hemisphere",
-        col_group_order="size",
-    )
-    ax = matrixplot(
-        X,
-        col_meta=meta,
-        row_meta=meta,
-        col_group="hemisphere",
-        row_item_order="cell_size",
-    )
-
-
-def test_matrixplot_sparse():
-    X = er_np(10, 0.5)
-    adjplot(csr_matrix(X), plot_type="scattermap")
+    
+    
+    def test_matrixplot_sparse(self):
+        X = er_np(10, 0.5)
+        adjplot(csr_matrix(X), plot_type="scattermap")

--- a/tests/test_plot_matrix.py
+++ b/tests/test_plot_matrix.py
@@ -1,12 +1,14 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
+import unittest
+
 import numpy as np
 import pandas as pd
-import unittest
+from scipy.sparse import csr_matrix
+
 from graspologic.plot.plot_matrix import adjplot, matrixplot
 from graspologic.simulations.simulations import er_np
-from scipy.sparse import csr_matrix
 
 
 class TestPlotMatrix(unittest.TestCase):

--- a/tests/test_plot_matrix.py
+++ b/tests/test_plot_matrix.py
@@ -12,7 +12,6 @@ from graspologic.simulations.simulations import er_np
 
 
 class TestPlotMatrix(unittest.TestCase):
-
     def test_adjplot_inputs(self):
         X = er_np(100, 0.5)
         meta = pd.DataFrame(
@@ -22,13 +21,13 @@ class TestPlotMatrix(unittest.TestCase):
                 "cell_size": np.random.randint(10, size=100),
             }
         )
-    
+
         # test matrix
         with self.assertRaises(TypeError):
             adjplot(data="input", meta=meta)
         with self.assertRaises(ValueError):
             adjplot(data=np.zeros((2, 2, 2)), meta=meta)
-    
+
         # test meta
         with self.assertRaises(ValueError):
             bad_meta = pd.DataFrame(
@@ -39,11 +38,11 @@ class TestPlotMatrix(unittest.TestCase):
                 }
             )
             adjplot(X, meta=bad_meta)
-    
+
         # test plot type
         with self.assertRaises(ValueError):
             adjplot(X, plot_type="bad plottype")
-    
+
         # test sorting_kws
         with self.assertRaises(TypeError):
             adjplot(X, meta=meta, group=123)
@@ -61,8 +60,7 @@ class TestPlotMatrix(unittest.TestCase):
             adjplot(X, meta=meta, item_order="bad value")
         with self.assertRaises(ValueError):
             adjplot(X, meta=meta, color="bad value")
-    
-    
+
     def test_adjplot_output(self):
         """
         simple function to see if plot is made without errors
@@ -79,13 +77,11 @@ class TestPlotMatrix(unittest.TestCase):
         ax = adjplot(X, meta=meta, group="hemisphere")
         ax = adjplot(X, meta=meta, group="hemisphere", group_order="size")
         ax = adjplot(X, meta=meta, group="hemisphere", item_order="cell_size")
-    
-    
+
     def test_adjplot_sparse(self):
         X = er_np(10, 0.5)
         adjplot(csr_matrix(X), plot_type="scattermap")
-    
-    
+
     def test_matrix_inputs(self):
         X = er_np(100, 0.5)
         meta = pd.DataFrame(
@@ -95,13 +91,13 @@ class TestPlotMatrix(unittest.TestCase):
                 "cell_size": np.random.randint(10, size=100),
             }
         )
-    
+
         # test matrix
         with self.assertRaises(TypeError):
             matrixplot(data="input", col_meta=meta, row_meta=meta)
         with self.assertRaises(ValueError):
             matrixplot(data=np.zeros((2, 2, 2)), col_meta=meta, row_meta=meta)
-    
+
         # test meta
         with self.assertRaises(ValueError):
             bad_meta = pd.DataFrame(
@@ -112,17 +108,21 @@ class TestPlotMatrix(unittest.TestCase):
                 }
             )
             matrixplot(X, col_meta=bad_meta, row_meta=bad_meta)
-    
+
         # test plot type
         with self.assertRaises(ValueError):
             matrixplot(X, plot_type="bad plottype", col_meta=meta, row_meta=meta)
-    
+
         # test sorting_kws
         with self.assertRaises(TypeError):
             matrixplot(X, col_meta=meta, row_meta=meta, col_group=123, row_group=123)
         with self.assertRaises(TypeError):
             matrixplot(
-                X, col_meta=meta, col_group_order=123, row_meta=meta, row_group_order=123
+                X,
+                col_meta=meta,
+                col_group_order=123,
+                row_meta=meta,
+                row_group_order=123,
             )
         with self.assertRaises(TypeError):
             matrixplot(
@@ -162,8 +162,7 @@ class TestPlotMatrix(unittest.TestCase):
                 row_meta=meta,
                 row_color="bad value",
             )
-    
-    
+
     def test_matrix_output(self):
         """
         simple function to see if plot is made without errors
@@ -192,8 +191,7 @@ class TestPlotMatrix(unittest.TestCase):
             col_group="hemisphere",
             row_item_order="cell_size",
         )
-    
-    
+
     def test_matrixplot_sparse(self):
         X = er_np(10, 0.5)
         adjplot(csr_matrix(X), plot_type="scattermap")

--- a/tests/test_ptr.py
+++ b/tests/test_ptr.py
@@ -2,8 +2,10 @@
 # Licensed under the MIT License.
 
 import unittest
+
 import numpy as np
-from graspologic.utils import pass_to_ranks, is_unweighted
+
+from graspologic.utils import is_unweighted, pass_to_ranks
 
 
 class TestPTR(unittest.TestCase):

--- a/tests/test_rdpg_corr.py
+++ b/tests/test_rdpg_corr.py
@@ -5,11 +5,9 @@ import unittest
 from graspologic.simulations.simulations import sample_edges, p_from_latent
 from graspologic.simulations.rdpg_corr import rdpg_corr
 import numpy as np
-import pytest
-import warnings
 
 
-class Test_RDPG_Corr(unittest.TestCase):
+class TestRDPGCorr(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.r = 0.3

--- a/tests/test_rdpg_corr.py
+++ b/tests/test_rdpg_corr.py
@@ -2,9 +2,11 @@
 # Licensed under the MIT License.
 
 import unittest
-from graspologic.simulations.simulations import sample_edges, p_from_latent
-from graspologic.simulations.rdpg_corr import rdpg_corr
+
 import numpy as np
+
+from graspologic.simulations.rdpg_corr import rdpg_corr
+from graspologic.simulations.simulations import p_from_latent, sample_edges
 
 
 class TestRDPGCorr(unittest.TestCase):

--- a/tests/test_seedless_procrustes.py
+++ b/tests/test_seedless_procrustes.py
@@ -5,8 +5,8 @@ import unittest
 
 import numpy as np
 from scipy import stats
-from graspologic.align import SignFlips
-from graspologic.align import SeedlessProcrustes
+
+from graspologic.align import SeedlessProcrustes, SignFlips
 
 
 class TestSeedlessProcrustes(unittest.TestCase):

--- a/tests/test_select_dimension.py
+++ b/tests/test_select_dimension.py
@@ -74,12 +74,10 @@ class TestSelectDimension(unittest.TestCase):
             bad_X = np.random.normal(size=100).reshape(100, -1)
             select_dimension(X=bad_X)
 
-
     def test_output_synthetic(self):
         data, l = generate_data(10, 3)
         elbows, _, _ = select_dimension(X=data, n_elbows=2, return_likelihoods=True)
         assert_equal(elbows, [2, 4])
-
 
     def test_output_simple(self):
         """
@@ -88,7 +86,6 @@ class TestSelectDimension(unittest.TestCase):
         X = np.array([10, 9, 3, 2, 1])
         elbows, _ = select_dimension(X, n_elbows=1)
         assert_equal(elbows[0], 2)
-
 
     def test_output_uniform(self):
         """
@@ -101,7 +98,6 @@ class TestSelectDimension(unittest.TestCase):
         X = np.sort(np.hstack([x1, x2]))[::-1]
         elbows, _ = select_dimension(X, n_elbows=1)
         assert_equal(elbows[0], 50)
-
 
     def test_output_two_block_sbm(self):
         np.random.seed(10)

--- a/tests/test_select_dimension.py
+++ b/tests/test_select_dimension.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import numpy as np
 import unittest
+
+import numpy as np
 from numpy.testing import assert_equal
 from scipy.linalg import orth
 

--- a/tests/test_select_dimension.py
+++ b/tests/test_select_dimension.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 import numpy as np
-import pytest
+import unittest
 from numpy.testing import assert_equal
 from scipy.linalg import orth
 
@@ -24,88 +24,89 @@ def generate_data(n=10, elbows=3, seed=1):
     return A, d
 
 
-def test_invalid_inputes():
-    X, D = generate_data()
+class TestSelectDimension(unittest.TestCase):
+    def test_invalid_inputes(self):
+        X, D = generate_data()
 
-    # invalid n_elbows
-    with pytest.raises(ValueError):
-        bad_n_elbows = -2
-        select_dimension(X, n_elbows=bad_n_elbows)
+        # invalid n_elbows
+        with self.assertRaises(ValueError):
+            bad_n_elbows = -2
+            select_dimension(X, n_elbows=bad_n_elbows)
 
-    with pytest.raises(ValueError):
-        bad_n_elbows = "string"
-        select_dimension(X, n_elbows=bad_n_elbows)
+        with self.assertRaises(ValueError):
+            bad_n_elbows = "string"
+            select_dimension(X, n_elbows=bad_n_elbows)
 
-    # invalid n_components
-    with pytest.raises(ValueError):
-        bad_n_components = -1
-        select_dimension(X, n_components=bad_n_components)
+        # invalid n_components
+        with self.assertRaises(ValueError):
+            bad_n_components = -1
+            select_dimension(X, n_components=bad_n_components)
 
-    with pytest.raises(ValueError):
-        bad_n_components = "string"
-        select_dimension(X, n_components=bad_n_components)
+        with self.assertRaises(ValueError):
+            bad_n_components = "string"
+            select_dimension(X, n_components=bad_n_components)
 
-    # invalid threshold
-    with pytest.raises(ValueError):
-        bad_threshold = -2
-        select_dimension(X, threshold=bad_threshold)
+        # invalid threshold
+        with self.assertRaises(ValueError):
+            bad_threshold = -2
+            select_dimension(X, threshold=bad_threshold)
 
-    with pytest.raises(ValueError):
-        bad_threshold = "string"
-        select_dimension(X, threshold=bad_threshold)
+        with self.assertRaises(ValueError):
+            bad_threshold = "string"
+            select_dimension(X, threshold=bad_threshold)
 
-    with pytest.raises(IndexError):
-        bad_threshold = 1000000
-        select_dimension(X, threshold=bad_threshold)
+        with self.assertRaises(IndexError):
+            bad_threshold = 1000000
+            select_dimension(X, threshold=bad_threshold)
 
-    # invalid X
-    with pytest.raises(ValueError):
-        bad_X = -2
-        select_dimension(X=bad_X)
+        # invalid X
+        with self.assertRaises(ValueError):
+            bad_X = -2
+            select_dimension(X=bad_X)
 
-    with pytest.raises(ValueError):
-        # input is tensor
-        bad_X = np.random.normal(size=(100, 10, 10))
-        select_dimension(X=bad_X)
+        with self.assertRaises(ValueError):
+            # input is tensor
+            bad_X = np.random.normal(size=(100, 10, 10))
+            select_dimension(X=bad_X)
 
-    with pytest.raises(ValueError):
-        bad_X = np.random.normal(size=100).reshape(100, -1)
-        select_dimension(X=bad_X)
-
-
-def test_output_synthetic():
-    data, l = generate_data(10, 3)
-    elbows, _, _ = select_dimension(X=data, n_elbows=2, return_likelihoods=True)
-    assert_equal(elbows, [2, 4])
+        with self.assertRaises(ValueError):
+            bad_X = np.random.normal(size=100).reshape(100, -1)
+            select_dimension(X=bad_X)
 
 
-def test_output_simple():
-    """
-    Elbow should be at 2.
-    """
-    X = np.array([10, 9, 3, 2, 1])
-    elbows, _ = select_dimension(X, n_elbows=1)
-    assert_equal(elbows[0], 2)
+    def test_output_synthetic(self):
+        data, l = generate_data(10, 3)
+        elbows, _, _ = select_dimension(X=data, n_elbows=2, return_likelihoods=True)
+        assert_equal(elbows, [2, 4])
 
 
-def test_output_uniform():
-    """
-    Generate two sets of synthetic eigenvalues based on two uniform distributions.
-    The elbow must be at 50.
-    """
-    np.random.seed(9)
-    x1 = np.random.uniform(0, 45, 50)
-    x2 = np.random.uniform(55, 100, 50)
-    X = np.sort(np.hstack([x1, x2]))[::-1]
-    elbows, _ = select_dimension(X, n_elbows=1)
-    assert_equal(elbows[0], 50)
+    def test_output_simple(self):
+        """
+        Elbow should be at 2.
+        """
+        X = np.array([10, 9, 3, 2, 1])
+        elbows, _ = select_dimension(X, n_elbows=1)
+        assert_equal(elbows[0], 2)
 
 
-def test_output_two_block_sbm():
-    np.random.seed(10)
-    n_communities = [100, 100]
-    P = np.array([[0.5, 0.1], [0.1, 0.5]])
-    A = sbm(n_communities, P)
+    def test_output_uniform(self):
+        """
+        Generate two sets of synthetic eigenvalues based on two uniform distributions.
+        The elbow must be at 50.
+        """
+        np.random.seed(9)
+        x1 = np.random.uniform(0, 45, 50)
+        x2 = np.random.uniform(55, 100, 50)
+        X = np.sort(np.hstack([x1, x2]))[::-1]
+        elbows, _ = select_dimension(X, n_elbows=1)
+        assert_equal(elbows[0], 50)
 
-    elbows, _ = select_dimension(A, n_elbows=2)
-    assert_equal(elbows[0], 2)
+
+    def test_output_two_block_sbm(self):
+        np.random.seed(10)
+        n_communities = [100, 100]
+        P = np.array([[0.5, 0.1], [0.1, 0.5]])
+        A = sbm(n_communities, P)
+
+        elbows, _ = select_dimension(A, n_elbows=2)
+        assert_equal(elbows[0], 2)

--- a/tests/test_sg.py
+++ b/tests/test_sg.py
@@ -1,10 +1,12 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import graspologic.subgraph as sg
 import unittest
+
 import numpy as np
 from numpy.testing import assert_equal
+
+import graspologic.subgraph as sg
 
 
 class TestEstimateSubgraph(unittest.TestCase):

--- a/tests/test_sims.py
+++ b/tests/test_sims.py
@@ -2,13 +2,11 @@
 # Licensed under the MIT License.
 
 import unittest
+
 import numpy as np
+
 from graspologic.simulations import *
-from graspologic.utils.utils import (
-    is_symmetric,
-    is_loopless,
-    symmetrize,
-)
+from graspologic.utils.utils import is_loopless, is_symmetric, symmetrize
 
 
 def remove_diagonal(A):

--- a/tests/test_sims.py
+++ b/tests/test_sims.py
@@ -2,15 +2,12 @@
 # Licensed under the MIT License.
 
 import unittest
-import graspologic as gs
 import numpy as np
-import networkx as nx
 from graspologic.simulations import *
 from graspologic.utils.utils import (
     is_symmetric,
     is_loopless,
     symmetrize,
-    cartesian_product,
 )
 
 
@@ -24,7 +21,7 @@ def remove_diagonal(A):
     return A[dind]
 
 
-class Test_ER(unittest.TestCase):
+class TestER(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.n = 20
@@ -48,7 +45,7 @@ class Test_ER(unittest.TestCase):
         self.assertTrue(A.shape == (self.n, self.n))
 
 
-class Test_ZINM(unittest.TestCase):
+class TestZINM(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.n = 20
@@ -192,7 +189,7 @@ class Test_ZINM(unittest.TestCase):
             er_nm(self.n, m)
 
 
-class Test_ZINP(unittest.TestCase):
+class TestZINP(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.n = 50
@@ -350,7 +347,7 @@ class Test_ZINP(unittest.TestCase):
             er_np(self.n, self.p, dc=dc)
 
 
-class Test_WSBM(unittest.TestCase):
+class TestWSBM(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # 120 vertex graph w one community having 50 and another
@@ -818,7 +815,7 @@ class Test_WSBM(unittest.TestCase):
             sbm(self.n, self.Psy, dc=dc, dc_kws=dc_kws)
 
 
-class Test_RDPG(unittest.TestCase):
+class TestRDPG(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.n = [50, 70]
@@ -889,7 +886,7 @@ class Test_RDPG(unittest.TestCase):
         self.assertTrue(is_loopless(g))
 
 
-class Test_MMSBM(unittest.TestCase):
+class TestMMSBM(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # 120 vertex graph

--- a/tests/test_sims_corr.py
+++ b/tests/test_sims_corr.py
@@ -2,12 +2,14 @@
 # Licensed under the MIT License.
 
 import unittest
+
+import numpy as np
+
 from graspologic.simulations.simulations_corr import (
-    sample_edges_corr,
     er_corr,
+    sample_edges_corr,
     sbm_corr,
 )
-import numpy as np
 
 
 class TestSampleCorr(unittest.TestCase):

--- a/tests/test_sims_corr.py
+++ b/tests/test_sims_corr.py
@@ -8,11 +8,9 @@ from graspologic.simulations.simulations_corr import (
     sbm_corr,
 )
 import numpy as np
-import pytest
-import warnings
 
 
-class Test_Sample_Corr(unittest.TestCase):
+class TestSampleCorr(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.n = 500
@@ -38,10 +36,10 @@ class Test_Sample_Corr(unittest.TestCase):
             R = "0.5"
             sample_edges_corr(self.P, R, directed=False, loops=False)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             sample_edges_corr(self.P, self.r, directed="hey", loops=False)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             sample_edges_corr(self.P, self.r, directed=False, loops=6)
 
     def test_sample_edges_corr(self):
@@ -67,7 +65,7 @@ class Test_Sample_Corr(unittest.TestCase):
         self.assertTrue(g2.shape == (self.n, self.n))
 
 
-class Test_ER_Corr(unittest.TestCase):
+class TestERCorr(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.n = 500
@@ -125,7 +123,7 @@ class Test_ER_Corr(unittest.TestCase):
         self.assertTrue(g2.shape == (self.n, self.n))
 
 
-class Test_SBM_Corr(unittest.TestCase):
+class TestSBMCorr(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.n = [100, 100]
@@ -166,10 +164,10 @@ class Test_SBM_Corr(unittest.TestCase):
             r = 5.0
             sbm_corr(self.n, self.p, r, directed=False, loops=False)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             sbm_corr(self.n, self.p, self.r, directed="hey", loops=False)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             sbm_corr(self.n, self.p, self.r, directed=False, loops=6)
 
     def test_sbm_corr(self):

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -1,9 +1,0 @@
-# Copyright (c) Microsoft Corporation and contributors.
-# Licensed under the MIT License.
-
-import graspologic
-import numpy as np
-
-from sklearn.utils.estimator_checks import check_estimator
-
-check_estimator(graspologic.embed.ClassicalMDS())

--- a/tests/test_spectral_embed.py
+++ b/tests/test_spectral_embed.py
@@ -6,7 +6,7 @@ import unittest
 import networkx as nx
 import numpy as np
 import pandas as pd
-from numpy.random import poisson, normal
+from numpy.random import normal, poisson
 from numpy.testing import assert_equal
 from scipy.sparse import csr_matrix
 from sklearn.base import clone
@@ -15,7 +15,7 @@ from sklearn.metrics import adjusted_rand_score, pairwise_distances
 
 from graspologic.embed.ase import AdjacencySpectralEmbed
 from graspologic.embed.lse import LaplacianSpectralEmbed
-from graspologic.simulations.simulations import er_np, er_nm, sbm
+from graspologic.simulations.simulations import er_nm, er_np, sbm
 from graspologic.utils import remove_vertices
 
 

--- a/tests/test_spectral_nomination.py
+++ b/tests/test_spectral_nomination.py
@@ -3,10 +3,12 @@
 
 import itertools
 import unittest
+
 import numpy as np
+
 from graspologic.embed.ase import AdjacencySpectralEmbed
-from graspologic.simulations.simulations import sbm
 from graspologic.nominate import SpectralVertexNomination
+from graspologic.simulations.simulations import sbm
 
 # global constants for tests
 n_verts = 50

--- a/tests/test_spectral_nomination.py
+++ b/tests/test_spectral_nomination.py
@@ -51,7 +51,9 @@ class TestSpectralVertexNominatorOutputs(unittest.TestCase):
         svn = SpectralVertexNomination(input_graph=False)
         with self.assertRaises(IndexError):
             self._nominate(
-                np.zeros((10, 20), dtype=np.int), np.zeros(3, dtype=np.int), nominator=svn
+                np.zeros((10, 20), dtype=np.int),
+                np.zeros(3, dtype=np.int),
+                nominator=svn,
             )
         # adj matrix should be square
         with self.assertRaises(IndexError):

--- a/tests/test_spectral_nomination.py
+++ b/tests/test_spectral_nomination.py
@@ -1,4 +1,8 @@
-import pytest
+# Copyright (c) Microsoft Corporation and contributors.
+# Licensed under the MIT License.
+
+import itertools
+import unittest
 import numpy as np
 from graspologic.embed.ase import AdjacencySpectralEmbed
 from graspologic.simulations.simulations import sbm
@@ -13,156 +17,92 @@ embeder = AdjacencySpectralEmbed()
 pre_embeded = embeder.fit_transform(adj)
 
 
-def _nominate(X, seed, nominator=None, k=None):
-    if nominator is None:
-        nominator = SpectralVertexNomination(n_neighbors=k)
-    nominator.fit(X)
-    n_verts = X.shape[0]
-    nom_list, dists = nominator.predict(seed)
-    assert nom_list.shape == (n_verts, seed.shape[0])
-    assert dists.shape == (n_verts, seed.shape[0])
-    return nom_list
+class TestSpectralVertexNominatorOutputs(unittest.TestCase):
+    def _nominate(self, X, seed, nominator=None, k=None):
+        if nominator is None:
+            nominator = SpectralVertexNomination(n_neighbors=k)
+        nominator.fit(X)
+        n_verts = X.shape[0]
+        nom_list, dists = nominator.predict(seed)
+        self.assertEqual(nom_list.shape, (n_verts, seed.shape[0]))
+        self.assertEqual(dists.shape, (n_verts, seed.shape[0]))
+        return nom_list
 
-
-def _test_seed_input_dimensions():
-    with pytest.raises(IndexError):
-        _nominate(adj, np.zeros((5, 5, 5), dtype=np.int))
-
-
-def _test_seed_shape():
-    with pytest.raises(IndexError):
-        _nominate(adj, np.zeros((1, 50), dtype=np.int))
-
-
-def _test_seed_input_array_dtype():
-    with pytest.raises(TypeError):
-        _nominate(adj, np.random.random((10, 2)))
-
-
-def _test_seed_input_type():
-    with pytest.raises(TypeError):
-        _nominate(adj, [0] * 10)
-
-
-def _test_X_input_type():
-    with pytest.raises(TypeError):
-        _nominate([[0] * 10] * 10, np.zeros(3, dtype=np.int))
-
-
-def _test_X_array_dtype():
-    with pytest.raises(TypeError):
-        _nominate(np.random.random((10, 10)), np.zeros(3, dtype=np.int))
-
-
-def _test_X_input_dimensions():
-    with pytest.raises(IndexError):
-        _nominate(np.zeros((5, 5, 5), dtype=np.int), np.zeros(3, dtype=np.int))
-
-
-def _test_embedding_dimensions():
-    # embedding should have less cols than rows.
-    svn = SpectralVertexNomination(input_graph=False)
-    with pytest.raises(IndexError):
-        _nominate(
-            np.zeros((10, 20), dtype=np.int), np.zeros(3, dtype=np.int), nominator=svn
-        )
-
-
-def _test_adjacency_shape():
-    # adj matrix should be square
-    with pytest.raises(IndexError):
-        _nominate(np.zeros((3, 4), dtype=np.int), np.zeros(3, dtype=np.int))
-
-
-def _test_input_graph_bool_type():
-    # input graph param has wrong type
-    with pytest.raises(TypeError):
-        svn = SpectralVertexNomination(input_graph=4)
-
-
-def _test_k_type():
-    # k of wrong type
-    with pytest.raises(TypeError):
-        _nominate(adj, np.zeros(3, dtype=np.int), k="hello world")
-
-
-def _test_k_value():
-    # k should be > 0
-    with pytest.raises(ValueError):
-        _nominate(adj, np.zeros(3, dtype=np.int), k=0)
-
-
-def _test_embedder_type():
-    # embedder must be BaseSpectralEmbed or str
-    with pytest.raises(TypeError):
-        svn = SpectralVertexNomination(embedder=45)
-
-
-def _test_embedder_value():
-    with pytest.raises(ValueError):
-        svn = SpectralVertexNomination(embedder="hi")
-        _nominate(adj, np.zeros(3, dtype=int), nominator=svn)
-
-
-class TestSpectralVertexNominatorOutputs:
     def test_seed_inputs(self):
-        _test_seed_input_dimensions()
-        _test_seed_shape()
-        _test_seed_input_array_dtype()
-        _test_seed_input_type()
+        with self.assertRaises(IndexError):
+            self._nominate(adj, np.zeros((5, 5, 5), dtype=np.int))
+        with self.assertRaises(IndexError):
+            self._nominate(adj, np.zeros((1, 50), dtype=np.int))
+        with self.assertRaises(TypeError):
+            self._nominate(adj, np.random.random((10, 2)))
+        with self.assertRaises(TypeError):
+            self._nominate(adj, [0] * 10)
 
     def test_X_inputs(self):
-        _test_X_array_dtype()
-        _test_X_input_dimensions()
-        _test_X_input_type()
-        _test_embedding_dimensions()
-        _test_adjacency_shape()
+        with self.assertRaises(TypeError):
+            self._nominate(np.random.random((10, 10)), np.zeros(3, dtype=np.int))
+        with self.assertRaises(IndexError):
+            self._nominate(np.zeros((5, 5, 5), dtype=np.int), np.zeros(3, dtype=np.int))
+        with self.assertRaises(TypeError):
+            self._nominate([[0] * 10] * 10, np.zeros(3, dtype=np.int))
+        # embedding should have fewer cols than rows.
+        svn = SpectralVertexNomination(input_graph=False)
+        with self.assertRaises(IndexError):
+            self._nominate(
+                np.zeros((10, 20), dtype=np.int), np.zeros(3, dtype=np.int), nominator=svn
+            )
+        # adj matrix should be square
+        with self.assertRaises(IndexError):
+            self._nominate(np.zeros((3, 4), dtype=np.int), np.zeros(3, dtype=np.int))
 
     def _test_k(self):
-        _test_k_value()
-        _test_k_type()
+        # k should be > 0
+        with self.assertRaises(ValueError):
+            self._nominate(adj, np.zeros(3, dtype=np.int), k=0)
+        # k of wrong type
+        with self.assertRaises(TypeError):
+            self._nominate(adj, np.zeros(3, dtype=np.int), k="hello world")
 
     def test_constructor_inputs(self):
-        _test_embedder_value()
+        with self.assertRaises(ValueError):
+            svn = SpectralVertexNomination(embedder="hi")
+            self._nominate(adj, np.zeros(3, dtype=int), nominator=svn)
 
     def test_constructor_inputs1(self):
-        _test_embedder_type()
+        # embedder must be BaseSpectralEmbed or str
+        with self.assertRaises(TypeError):
+            svn = SpectralVertexNomination(embedder=45)
 
     def test_constructor_inputs2(self):
-        _test_input_graph_bool_type()
+        # input graph param has wrong type
+        with self.assertRaises(TypeError):
+            svn = SpectralVertexNomination(input_graph=4)
 
-    @pytest.mark.parametrize(
-        "nominator",
-        [
-            SpectralVertexNomination(embedder="ASE"),
-            SpectralVertexNomination(embedder="LSE"),
-            SpectralVertexNomination(embedder=embeder),
-        ],
-    )
-    @pytest.mark.parametrize(
-        "seed",
-        [
-            np.array([8]),
-            np.array([2, 6, 9, 15, 25]),
-            np.arange(n_verts - 1, dtype=np.int),
-        ],
-    )
-    def test_basic_unattributed(self, nominator, seed):
+    def test_basic_unattributed(self):
         """
         Runs two attributed seeds and two unattributed seeds with each nominator.
         Ensures all options work. Should be fast. Nested parametrization tests all
         combinations of listed parameters.
         """
-        _nominate(adj, seed, nominator)
-
-    @pytest.mark.parametrize(
-        "seed",
-        [
+        nominators = [
+            SpectralVertexNomination(embedder="ASE"),
+            SpectralVertexNomination(embedder="LSE"),
+            SpectralVertexNomination(embedder=embeder),
+        ]
+        seeds = [
             np.array([8]),
             np.array([2, 6, 9, 15, 25]),
             np.arange(n_verts - 1, dtype=np.int),
-        ],
-    )
-    def test_pre_embedded(self, seed):
-        svn = SpectralVertexNomination(input_graph=False)
-        _nominate(pre_embeded, seed, nominator=svn)
+        ]
+        for nominator, seed in itertools.product(nominators, seeds):
+            self._nominate(adj, seed, nominator)
+
+    def test_pre_embedded(self):
+        seeds = [
+            np.array([8]),
+            np.array([2, 6, 9, 15, 25]),
+            np.arange(n_verts - 1, dtype=np.int),
+        ]
+        for seed in seeds:
+            svn = SpectralVertexNomination(input_graph=False)
+            self._nominate(pre_embeded, seed, nominator=svn)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,10 +7,11 @@ from math import sqrt
 
 import networkx as nx
 import numpy as np
-from graspologic.utils import remap_labels
-from graspologic.utils import utils as gus
 from numpy.testing import assert_equal
 from scipy.sparse import csr_matrix
+
+from graspologic.utils import remap_labels
+from graspologic.utils import utils as gus
 
 
 class TestInput(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,12 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import logging
 import unittest
 import warnings
 from math import sqrt
 
 import networkx as nx
 import numpy as np
-import pytest
 from graspologic.utils import remap_labels
 from graspologic.utils import utils as gus
 from numpy.testing import assert_equal
@@ -530,18 +528,18 @@ class TestRemoveVertices(unittest.TestCase):
 
     def test_exceptions(self):
         # ensure proper errors are thrown when invalid inputs are passed.
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             gus.remove_vertices(9001, 0)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             nonsquare = np.vstack((self.directed, self.directed))
             gus.remove_vertices(nonsquare, 0)
 
-        with pytest.raises(IndexError):
+        with self.assertRaises(IndexError):
             indices = np.arange(len(self.directed) + 1)
             gus.remove_vertices(self.directed, indices)
 
-        with pytest.raises(IndexError):
+        with self.assertRaises(IndexError):
             idx = len(self.directed) + 1
             gus.remove_vertices(self.directed, indices)
 
@@ -579,17 +577,17 @@ class TestRemapLabels(unittest.TestCase):
         assert_equal(y_true, y_pred_remapped)
 
     def test_inputs(self):
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             # handled by sklearn confusion matrix
             remap_labels(self.y_true[1:], self.y_pred)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             remap_labels(8, self.y_pred)
 
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             remap_labels(self.y_pred, self.y_true, return_map="hi")
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             remap_labels(self.y_pred, ["ant", "ant", "cat", "cat", "bird", "bird"])
 
 
@@ -598,7 +596,7 @@ class TestRemapNodeIds(unittest.TestCase):
         invalid_types = [str, int, list]
 
         for type in invalid_types:
-            with pytest.raises(TypeError):
+            with self.assertRaises(TypeError):
                 gus.remap_node_ids(graph=type())
 
     def test_remap_node_ids_unweighted_graph_raises_warning(self):

--- a/tests/test_vertex_nomination_via_SGM.py
+++ b/tests/test_vertex_nomination_via_SGM.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-import pytest
+import unittest
 import numpy as np
 from graspologic.nominate import VNviaSGM
 from graspologic.simulations import er_np
@@ -9,80 +9,80 @@ from graspologic.simulations import er_np
 np.random.seed(1)
 
 
-class TestVNviaSGM:
+class TestVNviaSGM(unittest.TestCase):
     def test_VNviaSGM_inputs(self):
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM(order_voi_subgraph=-1)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM(order_voi_subgraph=1.5)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM(order_seeds_subgraph=-1)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM(order_seeds_subgraph=1.5)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM(n_init=-1)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM(n_init=1.5)
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM(max_nominations=0)
 
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM().fit(
                 np.random.randn(3, 4),
                 np.random.randn(4, 4),
                 0,
                 [np.arange(2), np.arange(2)],
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM().fit(
                 np.random.randn(4, 4),
                 np.random.randn(3, 4),
                 0,
                 [np.arange(2), np.arange(2)],
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM().fit(
                 np.random.randn(4, 4),
                 np.random.randn(4, 4),
                 0,
                 [np.arange(2), 1],
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM().fit(
                 np.random.randn(4, 4),
                 np.random.randn(4, 4),
                 0,
                 np.random.randn(3, 3),
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM().fit(
                 np.random.randn(4, 4),
                 np.random.randn(4, 4),
                 0,
                 [np.arange(2), np.arange(3)],
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM().fit(
                 np.random.randn(4, 4),
                 np.random.randn(4, 4),
                 0,
                 [np.arange(5), np.arange(5)],
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM().fit(
                 np.random.randn(4, 4),
                 np.random.randn(4, 4),
                 0,
                 [[], []],
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM().fit(
                 np.random.randn(4, 4),
                 np.random.randn(4, 4),
                 0,
                 [[1, 1], [1, 2]],
             )
-        with pytest.raises(ValueError):
+        with self.assertRaises(ValueError):
             VNviaSGM().fit(
                 np.random.randn(4, 4),
                 np.random.randn(4, 4),
@@ -108,4 +108,4 @@ class TestVNviaSGM:
             g1, g2, voi, [kklst[0:nseeds, 0], kklst[0:nseeds, 1]]
         )
 
-        assert nomlst[0][0] == kklst[np.where(kklst[:, 0] == voi)[0][0], 1]
+        self.assertEqual(nomlst[0][0], kklst[np.where(kklst[:, 0] == voi)[0][0], 1])

--- a/tests/test_vertex_nomination_via_SGM.py
+++ b/tests/test_vertex_nomination_via_SGM.py
@@ -2,7 +2,9 @@
 # Licensed under the MIT License.
 
 import unittest
+
 import numpy as np
+
 from graspologic.nominate import VNviaSGM
 from graspologic.simulations import er_np
 


### PR DESCRIPTION
- [x] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [x] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

# `unittest` vs. `pytest` (mostly), and isort too

Pytest is great - it actually offers a whole heck of a lot more than the built-in unittest library. On top of that, we have every intention of using it as our runner going forward.

However, it doesn't play nicely with some python IDEs right out of the box, unlike unittest.  For the most part I ported everything over to using the unittest library.

Examples of changes:

```python
with pytest.raises(ValueError):
    ...
```

has become:
```python
with self.assertRaises(ValueError):
    ...
```

```python
   assert someBooleanReturningFunction(foo)
```
has become

```python
    self.assertTrue(someBooleanReturningFunction(foo))
```

**This is important, but also not used properly**.  The benefit to using `self.assertEqual/True/Whatever` is that you can also pass a message in to describe why a failing test might be bad. Otherwise it's virtually indistinguishable, for our cases.

I didn't have the expertise to give good messages on why certain things failing would be bad, so I didn't even try.

Lastly, I also didn't touch `test_casc.py` - this was the one class that didn't have a straightforward way to go from pytest -> unittest.  I'm sure it's possible, I just didn't want to get bogged down doing it right now.

# isort

I also finally roped isort into the mix.  I'm not sure that the workflow is going to work just yet, but I'm pretty sure it will.  The only thing I changed from the default is the awful multiline import to one that mimics the way we've mostly been doing it anyway.  It also automatically allows us to use the `black` profile so that isort and black don't fight over each other.


