### PR TITLE
Fixes #803 - clarify behaviour of Leiden and Hierarchical Leiden when…

### DIFF
--- a/graspologic/partition/leiden.py
+++ b/graspologic/partition/leiden.py
@@ -68,7 +68,7 @@ def _validate_and_build_edge_list(
                 f"{type(graph[0])}, {repr(graph[0])}"
             )
 
-        new_to_old = {}
+        new_to_old: Dict[str, Any] = {}
         stringified_new = []
 
         for source, target, weight in graph:
@@ -161,7 +161,7 @@ def _validate_common_arguments(
     is_weighted: Optional[bool] = None,
     weight_default: float = 1.0,
     check_directed: bool = True,
-):
+) -> None:
     if starting_communities is not None and not isinstance(starting_communities, dict):
         raise TypeError("starting_communities must be a dictionary")
     if not isinstance(extra_forced_iterations, int):

--- a/graspologic/partition/leiden.py
+++ b/graspologic/partition/leiden.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import warnings
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import graspologic_native as gn
@@ -9,6 +10,25 @@ import numpy as np
 import scipy
 
 from .. import utils
+
+
+def _put_node_in_node_str_map(node: Any, node_str_map: Dict[str, Any]) -> str:
+    """Add a node to the node_str_map, keyed by the node's string representation
+    which is returned by this function. Raise a ValueError in case of key collision."""
+    node_str = str(node)
+
+    if node_str in node_str_map and node_str_map[node_str] != node:
+        raise ValueError(
+            "str() representation collision in dataset. Please ensure that "
+            "str(node_id) cannot result in multiple node_ids being turned "
+            "into the same string. This exception is unlikely but would "
+            "result if a non primitive node ID of some sort had a "
+            "barebones __str__() definition for it."
+        )
+
+    node_str_map[node_str] = node
+
+    return node_str
 
 
 def _validate_and_build_edge_list(
@@ -35,7 +55,6 @@ def _validate_and_build_edge_list(
             "was found to be directed"
         )
 
-        # if we're already an edge list of str, str, float, return it
     if weight_default is not None and not isinstance(weight_default, (float, int)):
         raise TypeError("weight default must be a float or int")
 
@@ -53,22 +72,10 @@ def _validate_and_build_edge_list(
         stringified_new = []
 
         for source, target, weight in graph:
-            source_str = str(source)
-            target_str = str(target)
-            weight = float(weight)
-            if (source_str in new_to_old and new_to_old[source_str] != source) or (
-                target_str in new_to_old and new_to_old[target_str] != target
-            ):
-                raise ValueError(
-                    "str() representation collision in dataset. Please ensure that "
-                    "str(node_id) cannot result in multiple node_ids being turned "
-                    "into the same string. This exception is unlikely but would "
-                    "result if a non primitive node ID of some sort had a "
-                    "barebones __str__() definition for it."
-                )
-            new_to_old[source_str] = source
-            new_to_old[target_str] = target
-            stringified_new.append((source_str, target_str, weight))
+            source_str = _put_node_in_node_str_map(source, new_to_old)
+            target_str = _put_node_in_node_str_map(target, new_to_old)
+            weight_as_float = float(weight)
+            stringified_new.append((source_str, target_str, weight_as_float))
 
         return new_to_old, stringified_new
 
@@ -76,24 +83,16 @@ def _validate_and_build_edge_list(
         # will catch all networkx graph types
         try:
             new_to_old = {}
+            for node in graph.nodes:
+                _put_node_in_node_str_map(node, new_to_old)
+
             stringified_new = []
             for source, target, data in graph.edges(data=True):
                 source_str = str(source)
                 target_str = str(target)
                 weight = float(data.get(weight_attribute, weight_default))
-                if (source_str in new_to_old and new_to_old[source_str] != source) or (
-                    target_str in new_to_old and new_to_old[target_str] != target
-                ):
-                    raise ValueError(
-                        "str() representation collision in dataset. Please ensure that "
-                        "str(node_id) cannot result in multiple node_ids being turned "
-                        "into the same string. This exception is unlikely but would "
-                        "result if a non primitive node ID of some sort had a "
-                        "barebones __str__() definition for it."
-                    )
-                new_to_old[source_str] = source
-                new_to_old[target_str] = target
                 stringified_new.append((source_str, target_str, weight))
+
             return new_to_old, stringified_new
         except TypeError:
             # None is returned for the weight if it doesn't exist and a weight_default
@@ -137,10 +136,12 @@ def _validate_and_build_edge_list(
             for i in range(0, len(rows)):
                 row = rows[i]
                 column = columns[i]
-                new_to_old[str(row)] = row
-                new_to_old[str(column)] = column
                 if row <= column:
                     edges.append((str(row), str(column), float(graph[row, column])))
+
+            # populate the node map using values of the same type as the CSR rows
+            for i in np.arange(shape[0], dtype=rows.dtype):
+                new_to_old[str(i)] = i
 
         return new_to_old, edges
 
@@ -291,8 +292,8 @@ def leiden(
     -------
     Dict[str, int]
         The results of running leiden over the provided graph, a dictionary containing
-        mappings of node -> community id. The keys in the dictionary are the string
-        representations of the nodes.
+        mappings of node -> community id. Isolate nodes in the input graph are not returned
+        in the result.
 
     Raises
     ------
@@ -330,12 +331,12 @@ def leiden(
         raise TypeError("trials must be a positive integer")
     if trials < 1:
         raise ValueError("trials must be a positive integer")
-    node_id_mapping, graph = _validate_and_build_edge_list(
+    node_id_mapping, edges = _validate_and_build_edge_list(
         graph, is_weighted, weight_attribute, check_directed, weight_default
     )
 
     _modularity, partitions = gn.leiden(
-        edges=graph,
+        edges=edges,
         starting_communities=starting_communities,
         resolution=resolution,
         randomness=randomness,
@@ -348,6 +349,12 @@ def leiden(
     proper_partitions = {
         node_id_mapping[key]: value for key, value in partitions.items()
     }
+
+    if len(proper_partitions) < len(node_id_mapping):
+        warnings.warn(
+            "Leiden partitions do not contain all nodes from the input graph because input graph "
+            "contained isolate nodes."
+        )
 
     return proper_partitions
 
@@ -394,7 +401,12 @@ def _from_native(
 
 
 def hierarchical_leiden(
-    graph: Union[List[Tuple[str, str, float]], nx.Graph],
+    graph: Union[
+        List[Tuple[Any, Any, Union[int, float]]],
+        nx.Graph,
+        np.ndarray,
+        scipy.sparse.csr.csr_matrix,
+    ],
     max_cluster_size: int = 1000,
     starting_communities: Optional[Dict[str, int]] = None,
     extra_forced_iterations: int = 0,
@@ -512,7 +524,8 @@ def hierarchical_leiden(
         HierarchicalClusters identifying the state of every node and cluster at each
         level. The function
         :func:`graspologic.partition.HierarchicalCluster.final_hierarchical_clustering`
-        can be used to create a dictionary mapping of node -> cluster ID
+        can be used to create a dictionary mapping of node -> cluster ID. Isolate nodes
+        in the input graph are not returned in the result.
 
     Raises
     ------
@@ -565,6 +578,17 @@ def hierarchical_leiden(
         seed=random_seed,
     )
 
-    return [
-        _from_native(entry, node_id_mapping) for entry in hierarchical_clusters_native
-    ]
+    result_partitions = []
+    all_nodes = set()
+    for entry in hierarchical_clusters_native:
+        partition = _from_native(entry, node_id_mapping)
+        result_partitions.append(partition)
+        all_nodes.add(partition.node)
+
+    if len(result_partitions) < len(node_id_mapping):
+        warnings.warn(
+            "Leiden partitions do not contain all nodes from the input graph because input graph "
+            "contained isolate nodes."
+        )
+
+    return result_partitions

--- a/graspologic/partition/leiden.py
+++ b/graspologic/partition/leiden.py
@@ -141,7 +141,7 @@ def _validate_and_build_edge_list(
 
             # populate the node map using values of the same type as the CSR rows
             for i in np.arange(shape[0], dtype=rows.dtype):
-                new_to_old[str(i)] = i
+                _put_node_in_node_str_map(i, new_to_old)
 
         return new_to_old, edges
 

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -225,7 +225,9 @@ def is_unweighted(
         )
 
 
-def is_almost_symmetric(x: Union[np.ndarray, scipy.sparse.spmatrix], atol: float = 1e-15) -> bool:
+def is_almost_symmetric(
+    x: Union[np.ndarray, scipy.sparse.spmatrix], atol: float = 1e-15
+) -> bool:
     """
     Returns True if input x is nearly symmetric, which means that the entries differ by
     no more than atol.

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -225,11 +225,33 @@ def is_unweighted(
         )
 
 
-def is_almost_symmetric(X, atol=1e-15):
-    if (X.ndim != 2) or (X.shape[0] != X.shape[1]):
+def is_almost_symmetric(x: Union[np.ndarray, scipy.sparse.spmatrix], atol: float = 1e-15) -> bool:
+    """
+    Returns True if input x is nearly symmetric, which means that the entries differ by
+    no more than atol.
+
+    Parameters
+    ----------
+    x: Union[np.ndarray, scipy.sparse.spmatrix]
+        a square matrix
+    atol : float
+        a threshold for comparing the difference between off-diagonal entries
+        default 1e-15
+
+    Returns
+    -------
+    bool
+        True if x is a nearly symmetric square matrix
+
+    Raises
+    ------
+    TypeError
+        If the provided graph is not a numpy.ndarray or scipy.sparse.spmatrix
+    """
+    if (x.ndim != 2) or (x.shape[0] != x.shape[1]):
         return False
-    if isinstance(X, (np.ndarray, scipy.sparse.spmatrix)):
-        return abs(X - X.T).max() <= atol
+    if isinstance(x, (np.ndarray, scipy.sparse.spmatrix)):
+        return abs(x - x.T).max() <= atol
     else:
         raise TypeError("input a correct matrix type.")
 

--- a/tests/partition/test_leiden.py
+++ b/tests/partition/test_leiden.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 import unittest
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import networkx as nx
 import numpy as np
@@ -203,6 +203,118 @@ class TestLeiden(unittest.TestCase):
             self.assertTrue(isinstance(node_id, int))
 
 
+class TestLeidenIsolates(unittest.TestCase):
+    """
+    Tests to verify fix for Github issue: 803 - isolate nodes are dropped silently
+    """
+
+    def setUp(self) -> None:
+        # prepare a graph with an isolate node
+        self.graph: nx.Graph = nx.complete_graph(10)
+        nodelist = sorted(self.graph.nodes)
+        for node in nodelist[1:]:
+            self.graph.remove_edge(0, node)
+
+    def assert_isolate_not_in_result(self, partitions: Dict[str, int]):
+        """verify that isolate node was not returned"""
+        self.assertTrue(
+            0 not in partitions, "the isolate node is not in the result from leiden"
+        )
+        self.assertTrue(
+            3 in partitions, "a node that was not removed is in the result from leiden"
+        )
+        self.assertEqual(
+            9,
+            len(partitions),
+            "the result contains all nodes in the connected component",
+        )
+
+    def assert_isolate_not_in_hierarchical_result(
+        self, partitions: List[HierarchicalCluster]
+    ):
+        """verify that isolate node was not returned"""
+        all_nodes = {p.node for p in partitions}
+
+        self.assertTrue(
+            0 not in all_nodes, "the isolate node is not in the result from leiden"
+        )
+        self.assertTrue(
+            3 in all_nodes, "a node that was not removed is in the result from leiden"
+        )
+        self.assertEqual(
+            9,
+            len(all_nodes),
+            "the result contains all nodes in the connected component",
+        )
+
+    def test_isolate_nodes_in_nx_graph_are_not_returned(self):
+        self.assertEqual(
+            10,
+            len(self.graph.nodes),
+            "the input graph contains all nodes including isolate",
+        )
+
+        with self.assertWarnsRegex(
+            UserWarning, "isolate", msg="should warn about isolates in input graph"
+        ):
+            partitions = leiden(self.graph)
+
+        self.assert_isolate_not_in_result(partitions)
+
+        with self.assertWarnsRegex(
+            UserWarning, "isolate", msg="hierarchical leiden should warn about isolates"
+        ):
+            hierarchical_partitions = hierarchical_leiden(self.graph)
+
+        self.assert_isolate_not_in_hierarchical_result(hierarchical_partitions)
+
+    def test_isolate_nodes_in_ndarray_are_not_returned(self):
+        ndarray_adj_matrix = nx.to_numpy_array(self.graph)
+
+        self.assertEqual(
+            10,
+            ndarray_adj_matrix.shape[0],
+            "the input array contains all nodes including isolate",
+        )
+
+        with self.assertWarnsRegex(
+            UserWarning, "isolate", msg="should warn about isolates in input graph"
+        ):
+            partitions = leiden(ndarray_adj_matrix)
+
+        self.assert_isolate_not_in_result(partitions)
+
+        with self.assertWarnsRegex(
+            UserWarning, "isolate", msg="hierarchical leiden should warn about isolates"
+        ):
+            hierarchical_partitions = hierarchical_leiden(ndarray_adj_matrix)
+
+        self.assert_isolate_not_in_hierarchical_result(hierarchical_partitions)
+
+    def test_isolate_nodes_in_csr_matrix_are_not_returned(self):
+        sparse_adj_matrix = nx.to_scipy_sparse_matrix(self.graph)
+
+        self.assertEqual(
+            10,
+            sparse_adj_matrix.shape[0],
+            "the input csr contains all nodes including isolate",
+        )
+
+        with self.assertWarnsRegex(
+            UserWarning, "isolate", msg="should warn about isolates in input graph"
+        ):
+            partitions = leiden(sparse_adj_matrix)
+
+        self.assert_isolate_not_in_result(partitions)
+
+        with self.assertWarnsRegex(
+            UserWarning, "isolate", msg="hierarchical leiden should warn about isolates"
+        ):
+            hierarchical_partitions = hierarchical_leiden(sparse_adj_matrix)
+
+        self.assert_isolate_not_in_hierarchical_result(hierarchical_partitions)
+
+
 def add_edges_to_graph(graph: nx.Graph) -> nx.Graph:
     graph.add_edge("nick", "dwayne", weight=1.0)
     graph.add_edge("nick", "dwayne", weight=3.0)
@@ -223,6 +335,28 @@ class TestValidEdgeList(unittest.TestCase):
             weight_default=1.0,
         )
         self.assertEqual([], results[1])
+
+    def test_assert_list_does_not_contain_tuples(self):
+        edges = ["invalid"]
+        with self.assertRaisesRegex(TypeError, "list of tuples"):
+            _validate_and_build_edge_list(
+                graph=edges,
+                is_weighted=True,
+                weight_attribute="weight",
+                check_directed=False,
+                weight_default=1.0,
+            )
+
+    def test_assert_list_contains_misshapen_tuple(self):
+        edges = [(1, 2, 1.0, 1.0)]
+        with self.assertRaisesRegex(TypeError, "list of tuples"):
+            _validate_and_build_edge_list(
+                graph=edges,
+                is_weighted=True,
+                weight_attribute="weight",
+                check_directed=False,
+                weight_default=1.0,
+            )
 
     def test_assert_wrong_types_in_tuples(self):
         edges = [(True, 4, "sandwich")]
@@ -445,6 +579,39 @@ class TestValidEdgeList(unittest.TestCase):
         with self.assertRaises(ValueError):
             _validate_and_build_edge_list(
                 graph=scipy.sparse.csr_matrix(data),
+                is_weighted=True,
+                weight_attribute="weight",
+                check_directed=True,
+                weight_default=1.0,
+            )
+
+    def test_invalid_weight_default(self):
+        graph = nx.complete_graph(10)
+        with self.assertRaisesRegex(TypeError, "weight default"):
+            _validate_and_build_edge_list(
+                graph=graph,
+                is_weighted=True,
+                weight_attribute="weight",
+                check_directed=True,
+                weight_default="invalid",
+            )
+
+    def test_nx_graph_node_str_collision(self):
+        graph = nx.Graph()
+        graph.add_edge("1", 1, weight=1.0)
+        with self.assertRaisesRegex(ValueError, "representation collision"):
+            _validate_and_build_edge_list(
+                graph=graph,
+                is_weighted=True,
+                weight_attribute="weight",
+                check_directed=True,
+                weight_default=1.0,
+            )
+
+    def test_edgelist_node_str_collision(self):
+        with self.assertRaisesRegex(ValueError, "representation collision"):
+            _validate_and_build_edge_list(
+                graph=[("1", 1, 1.0)],
                 is_weighted=True,
                 weight_attribute="weight",
                 check_directed=True,


### PR DESCRIPTION
This change introduces a warning in the leiden and hierarchical_leiden functions when the input graph contains isolate nodes.

Some additional refactoring to increase test coverage is also included, mainly for _validate_and_build_edge_list

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->

- [ ] Does this PR add any new dependencies? no
- [ ] Does this PR modify any existing APIs? change in typing only for first param in hierarchical_leiden
   - [ ] Is the change to the API backwards compatible? yes
- [x] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate? err, no .. will do that now

#### Reference Issues/PRs

803

#### What does this implement/fix? Briefly explain your changes.
This change introduces a warning in the leiden and hierarchical_leiden functions when the input graph contains isolate nodes.

Some additional refactoring to increase test coverage is also included, mainly for _validate_and_build_edge_list
#### Any other comments?
