### PR TITLE
improve utils.is_unweighted for sparse graphs

### DIFF
--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -235,12 +235,7 @@ def is_unweighted(
     if isinstance(graph, np.ndarray):
         return ((graph == 0) | (graph == 1)).all()
     elif isinstance(graph, csr_matrix):
-        # brute force.  if anyone has a better way, please PR
-        rows, columns = graph.nonzero()
-        for i in range(0, len(rows)):
-            if graph[rows[i], columns[i]] != 1 and graph[rows[i], columns[i]] != 0:
-                return False
-        return True
+        return graph.count_nonzero() == (graph == 1).count_nonzero()
     elif isinstance(graph, nx.Graph):
         return nx.is_weighted(graph, weight=weight_attribute)
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -153,10 +153,42 @@ class TestChecks(unittest.TestCase):
             np.random.normal(size=nedge),
         )
 
-    def test_is_unweighted(self):
+    def test_is_unweighted_for_mixed_zeros_ones_ndarray(self):
         B = np.array([[0, 1, 0, 0], [1, 0, 1, 0], [0, 1.0, 0, 0], [1, 0, 1, 0]])
         self.assertTrue(gus.is_unweighted(B))
+
+    def test_is_unweighted_for_random_ndarray(self):
         self.assertFalse(gus.is_unweighted(self.A))
+
+    def test_is_unweighted_for_zeros_ndarray(self):
+        self.assertTrue(gus.is_unweighted(np.zeros((10, 10))))
+
+    def test_is_unweighted_for_ones_ndarray(self):
+        self.assertTrue(gus.is_unweighted(np.ones((10, 10))))
+
+    def test_is_unweighted_for_zeros_csr_matrix(self):
+        m = csr_matrix((10, 10))
+        self.assertTrue(gus.is_unweighted(m))
+
+    def test_is_unweighted_for_ones_csr_matrix(self):
+        m = csr_matrix(np.ones((10, 10)))
+        self.assertTrue(gus.is_unweighted(m))
+
+    def test_is_unweighted_for_mixed_zeros_ones_csr_matrix(self):
+        m = csr_matrix((10_000, 10_000))
+        m[0, 1] = 1
+        m[1, 1] = 0
+        m[9_999, 9_999] = 1.0
+        self.assertTrue(gus.is_unweighted(m))
+
+    def test_is_unweighted_for_random_csr_matrix(self):
+        dim = 10_000
+        num_nonzero = 20
+        rows = np.random.randint(0, dim, num_nonzero)
+        columns = np.random.randint(0, dim, num_nonzero)
+        m = csr_matrix((dim, dim))
+        m[rows, columns] = np.random.random(num_nonzero)
+        self.assertFalse(gus.is_unweighted(m))
 
     def test_is_fully_connected(self):
         # graph where node at index [3] only connects to self


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->

- [x] Does this PR add any new dependencies? no
- [x] Does this PR modify any existing APIs? no
   - [x] Is the change to the API backwards compatible? yes
- [x] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate? yes

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

1. Replace filtering Python loop that checks each nonzero entry with library methods that compare counts of nonzeros after applying a broadcast filter operation
2. Add unit tests to expand coverage for ndarray and csr_matrix inputs to utils.is_unweighted

#### Any other comments?
