### PR TITLE
Update `matplotlib` version specification to only disallow `3.3.*`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     graspologic-native>=1.0.0
     hyppo>=0.2.0
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
-    matplotlib>=3.0.0,<=3.3.0
+    matplotlib>=3.0.0,!=3.3.*
     networkx>=2.1
     numpy>=1.8.1
     POT>=0.7.0


### PR DESCRIPTION
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
Closes #726 

#### What does this implement/fix? Briefly explain your changes.
Updates the version spec to allow most recent versions of matplotlib

#### Any other comments?
I am still not sure EXACTLY which versions in 3.3.* raised an issue with one of our tests in `tests/test_plot.py`. Because of this, I am just changing the specification to not allow ANY version in 3.3.*, even though I think we could get more specific about what is actually broken. If anyone wants to investigate which versions are actually broken feel free. But for now, I think this is an improvement. 

I have tested 3.4.0 - 3.4.3 on my machine locally and tests passed.