### PR TITLE
Updated graspologic.plot.plot.screeplot to accept an ax argument for plt

### DIFF
--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -1405,6 +1405,7 @@ def screeplot(
     X: np.ndarray,
     title: str = "Scree plot",
     context: str = "talk",
+    ax: matplotlib.axes.Axes = None,
     font_scale: float = 1,
     figsize: Tuple[int, int] = (10, 5),
     cumulative: bool = True,
@@ -1422,6 +1423,8 @@ def screeplot(
         Plot title
     context :  None, or one of {talk (default), paper, notebook, poster}
         Seaborn plotting context
+    ax : None, or an Axes object detailing which axes the plot should be
+        plotted on
     font_scale : float, optional, default: 1
         Separate scaling factor to independently scale the size of the font
         elements.
@@ -1455,7 +1458,8 @@ def screeplot(
     else:
         y = D[:show_first]
     _ = plt.figure(figsize=figsize)
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
     xlabel = "Component"
     ylabel = "Variance explained"
     with sns.plotting_context(context=context, font_scale=font_scale):
@@ -1463,6 +1467,7 @@ def screeplot(
         plt.title(title)
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)
+        plt.axes(ax)
     return ax
 
 

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -1457,9 +1457,12 @@ def screeplot(
         y = np.cumsum(D[:show_first])
     else:
         y = D[:show_first]
-    _ = plt.figure(figsize=figsize)
+    fig = plt.figure(figsize=figsize)
     if ax is None:
         ax = plt.gca()
+    else:
+        ax.remove()
+        ax.set_figure(fig)
     xlabel = "Component"
     ylabel = "Variance explained"
     with sns.plotting_context(context=context, font_scale=font_scale):

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -17,6 +17,7 @@ from graspologic.plot.plot import (
     networkplot,
     pairplot,
     pairplot_with_gmm,
+    screeplot
 )
 from graspologic.simulations.simulations import er_np, sbm
 
@@ -363,6 +364,27 @@ class TestPlot(unittest.TestCase):
             edge_linewidth=0.6,
             ax=ax,
         )
+        
+    def test_screeplot_inputs(self):
+        X = np.random.rand(3,2)
+
+        with self.assertRaises(TypeError):
+            screeplot(X=X, show_first="test")
+
+        with self.assertRaises(TypeError):
+            screeplot(X=X, cumulative="test")
+
+
+    def test_screeplot_outputs(self):
+        """
+        simple function to see if plot is made without errors
+        """
+        X = np.random.rand(3,2)
+        title = "screee plot"
+        fig = gridplot(X)
+        fig = gridplot(X, title)
+        fig = gridplot(X, title, cumulative=1)
+        fig = gridplot(X, title, cumulative=1, show_first=1)
 
     def test_sort_inds(self):
         B = np.array(

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -17,7 +17,7 @@ from graspologic.plot.plot import (
     networkplot,
     pairplot,
     pairplot_with_gmm,
-    screeplot
+    screeplot,
 )
 from graspologic.simulations.simulations import er_np, sbm
 
@@ -364,9 +364,9 @@ class TestPlot(unittest.TestCase):
             edge_linewidth=0.6,
             ax=ax,
         )
-        
+
     def test_screeplot_inputs(self):
-        X = np.random.rand(3,2)
+        X = np.random.rand(3, 2)
 
         with self.assertRaises(TypeError):
             screeplot(X=X, show_first="test")
@@ -374,18 +374,17 @@ class TestPlot(unittest.TestCase):
         with self.assertRaises(TypeError):
             screeplot(X=X, cumulative="test")
 
-
     def test_screeplot_outputs(self):
         """
         simple function to see if plot is made without errors
         """
-        X = np.random.rand(3,2)
+        X = np.random.rand(3, 2)
         title = "screee plot"
         fig = screeplot(X)
         fig = screeplot(X, title)
-        fig = screeplot(X, title, cumulative=1)
-        fig = screeplot(X, title, cumulative=1, show_first=1)
-        fig = screeplot(X, title, cumulative=1, show_first=1, ax=plt.gca())
+        fig = screeplot(X, title, cumulative=True)
+        fig = screeplot(X, title, cumulative=True, show_first=1)
+        fig = screeplot(X, title, cumulative=True, show_first=1, ax=plt.gca())
 
     def test_sort_inds(self):
         B = np.array(

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -381,10 +381,11 @@ class TestPlot(unittest.TestCase):
         """
         X = np.random.rand(3,2)
         title = "screee plot"
-        fig = gridplot(X)
-        fig = gridplot(X, title)
-        fig = gridplot(X, title, cumulative=1)
-        fig = gridplot(X, title, cumulative=1, show_first=1)
+        fig = screeplot(X)
+        fig = screeplot(X, title)
+        fig = screeplot(X, title, cumulative=1)
+        fig = screeplot(X, title, cumulative=1, show_first=1)
+        fig = screeplot(X, title, cumulative=1, show_first=1, ax=plt.gca())
 
     def test_sort_inds(self):
         B = np.array(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->
- [X] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [X] Does this PR modify any existing APIs?
   - [X] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #840 

#### What does this implement/fix? Briefly explain your changes.
This PR gives the screeplot function an ax argument, which defaults to None. If the argument is None, the ax value will remain plt.gca(). This value is used in plt.axes(ax) so that the plot will appear on the gives axes. The function still returns ax, whether the given value or the plt.gca() value.

#### Any other comments?
