### PR TITLE
Fixed bug / suboptimality with leiden/hierarchical_leiden starting_communities

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ intersphinx_mapping = {
     "networkx": ("https://networkx.org/documentation/stable", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    "python": ("https://docs.python.org/3", None),
+    "python": ("https://docs.python.org/3.9", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     "seaborn": ("https://seaborn.pydata.org", None),
     "sklearn": ("https://scikit-learn.org/dev", None),

--- a/docs/reference/reference/partition.rst
+++ b/docs/reference/reference/partition.rst
@@ -16,5 +16,9 @@ Leiden and Hierarchical Leiden
 .. autofunction:: leiden
 
 .. autoclass:: HierarchicalCluster
+    :members:
+
+.. autoclass:: HierarchicalClusters
+    :members:
 
 .. autofunction:: hierarchical_leiden

--- a/graspologic/partition/__init__.py
+++ b/graspologic/partition/__init__.py
@@ -1,11 +1,17 @@
 # Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-from .leiden import HierarchicalCluster, hierarchical_leiden, leiden
+from .leiden import (
+    HierarchicalCluster,
+    HierarchicalClusters,
+    hierarchical_leiden,
+    leiden,
+)
 from .modularity import modularity, modularity_components
 
 __all__ = [
     "HierarchicalCluster",
+    "HierarchicalClusters",
     "hierarchical_leiden",
     "leiden",
     "modularity",

--- a/graspologic/partition/leiden.py
+++ b/graspologic/partition/leiden.py
@@ -191,7 +191,7 @@ def leiden(
     weight_default: Union[int, float] = 1.0,
     check_directed: bool = True,
     trials: int = 1,
-) -> Dict[str, int]:
+) -> Dict[Any, int]:
     """
     Leiden is a global network partitioning algorithm. Given a graph, it will iterate
     through the network node by node, and test for an improvement in our quality
@@ -220,10 +220,10 @@ def leiden(
         iteration. As there is an element of randomness to the Leiden algorithm, it is
         sometimes useful to set ``extra_forced_iterations`` to a number larger than 0
         where the process is forced to attempt further refinement.
-    resolution : float
+    resolution : Union[int, float]
         Default is ``1.0``. Higher resolution values lead to more communities and lower
         resolution values leads to fewer communities. Must be greater than 0.
-    randomness : float
+    randomness : Union[int, float]
         Default is ``0.001``. The larger the randomness value, the more exploration of
         the partition space is possible. This is a major difference from the Louvain
         algorithm, which is purely greedy in the partition exploration.
@@ -243,7 +243,7 @@ def leiden(
         matrices and attempt to determine whether it is weighted or not. This flag can
         short circuit this test and the values in the adjacency matrix will be treated
         as weights.
-    weight_default : float
+    weight_default : Union[int, float]
         Default is ``1.0``. If the graph is a networkx graph and the graph does not have
         a fully weighted sequence of edges, this default will be used. If the adjacency
         matrix is found or specified to be unweighted, this weight_default will be used
@@ -492,10 +492,10 @@ def hierarchical_leiden(
         iteration. As there is an element of randomness to the Leiden algorithm, it is
         sometimes useful to set ``extra_forced_iterations`` to a number larger than 0
         where the entire process is forced to attempt further refinement.
-    resolution : float
+    resolution : Union[int, float]
         Default is ``1.0``. Higher resolution values lead to more communities and lower
         resolution values leads to fewer communities. Must be greater than 0.
-    randomness : float
+    randomness : Union[int, float]
         Default is ``0.001``. The larger the randomness value, the more exploration of
         the partition space is possible. This is a major difference from the Louvain
         algorithm, which is purely greedy in the partition exploration.
@@ -515,7 +515,7 @@ def hierarchical_leiden(
         matrices and attempt to determine whether it is weighted or not. This flag can
         short circuit this test and the values in the adjacency matrix will be treated
         as weights.
-    weight_default : float
+    weight_default : Union[int, float]
         Default is ``1.0``. If the graph is a networkx graph and the graph does not
         have a fully weighted sequence of edges, this default will be used. If the
         adjacency matrix is found or specified to be unweighted, this weight_default

--- a/graspologic/partition/leiden.py
+++ b/graspologic/partition/leiden.py
@@ -208,11 +208,11 @@ def leiden(
         numpy.ndarray or scipy.sparse.csr.csr_matrix form. Please see the Notes section
         regarding node ids used.
     starting_communities : Optional[Dict[Any, int]]
-        Default is ``None``. An optional community mapping dictionary that contains a node 
+        Default is ``None``. An optional community mapping dictionary that contains a node
         id mapping to the community it belongs to. Please see the Notes section regarding
         node ids used.
 
-        If no community map is provided, the default behavior is to create a node 
+        If no community map is provided, the default behavior is to create a node
         community identity map, where every node is in their own community.
     extra_forced_iterations : int
         Default is ``0``. Leiden will run until a maximum quality score has been found
@@ -364,7 +364,7 @@ class HierarchicalCluster(NamedTuple):
 
 class HierarchicalClusters(List[HierarchicalCluster]):
     """
-    HierarchicalClusters is a subclass of Python's :class:`list` class with two 
+    HierarchicalClusters is a subclass of Python's :class:`list` class with two
     helper methods for retrieving dictionary views of the first and final
     level of hierarchical clustering in dictionary form.  The rest of the
     HierarchicalCluster entries in this list can be seen as a transition
@@ -373,12 +373,13 @@ class HierarchicalClusters(List[HierarchicalCluster]):
     with the two helper methods on this list providing you the starting point
     community map and ending point community map.
     """
+
     def first_level_hierarchical_clustering(self) -> Dict[Any, int]:
         """
         Returns
         -------
         Dict[Any, int]
-            The initial leiden algorithm clustering results as a dictionary 
+            The initial leiden algorithm clustering results as a dictionary
             of node id to community id.
         """
         return {entry.node: entry.cluster for entry in self if entry.level == 0}
@@ -388,7 +389,7 @@ class HierarchicalClusters(List[HierarchicalCluster]):
         Returns
         -------
         Dict[Any, int]
-            The last leiden algorithm clustering results as a dictionary 
+            The last leiden algorithm clustering results as a dictionary
             of node id to community id.
         """
         return {entry.node: entry.cluster for entry in self if entry.is_final_cluster}
@@ -479,11 +480,11 @@ def hierarchical_leiden(
         cluster's membership is < ``max_cluster_size`` or if they cannot be broken into
         more than one new community.
     starting_communities : Optional[Dict[Any, int]]
-        Default is ``None``. An optional community mapping dictionary that contains a node 
+        Default is ``None``. An optional community mapping dictionary that contains a node
         id mapping to the community it belongs to. Please see the Notes section regarding
         node ids used.
 
-        If no community map is provided, the default behavior is to create a node 
+        If no community map is provided, the default behavior is to create a node
         community identity map, where every node is in their own community.
     extra_forced_iterations : int
         Default is ``0``. Leiden will run until a maximum quality score has been found

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,10 +17,6 @@ ignore_missing_imports = True
 [mypy-gensim.models]
 ignore_missing_imports = True
 
-[mypy-graspologic_native]
-# temporary until .pyi file added to native code
-ignore_missing_imports = True  
-
 [mypy-matplotlib]
 ignore_missing_imports = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 packages = find:
@@ -29,7 +30,7 @@ install_requires =
     anytree>=2.8.0
     beartype>=0.9.0
     gensim>=3.8.0,<=3.9.0  # methods signatures changed in the 4.0.0beta release
-    graspologic-native>=1.0.0
+    graspologic-native>=1.1.1
     hyppo>=0.2.2
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,!=3.3.*

--- a/tests/partition/test_leiden.py
+++ b/tests/partition/test_leiden.py
@@ -8,9 +8,21 @@ import networkx as nx
 import numpy as np
 import pytest
 import scipy
+from beartype.roar import BeartypeCallHintPepParamException
 
-from graspologic.partition import HierarchicalCluster, hierarchical_leiden, leiden
-from graspologic.partition.leiden import _from_native, _validate_and_build_edge_list
+from graspologic.partition import (
+    HierarchicalCluster,
+    HierarchicalClusters,
+    hierarchical_leiden,
+    leiden,
+)
+from graspologic.partition.leiden import (
+    _adjacency_matrix_to_edge_list,
+    _edge_list_to_edge_list,
+    _from_native,
+    _IdentityMapper,
+    _nx_to_edge_list,
+)
 from tests.utils import data_file
 
 
@@ -23,19 +35,19 @@ class TestHierarchicalCluster(unittest.TestCase):
         # test from_native indirectly through calling graspologic.partition.hierarchical_leiden()
 
     def test_final_hierarchical_clustering(self):
-        with self.assertRaises(TypeError):
-            HierarchicalCluster.final_hierarchical_clustering("I am not a list")
 
-        hierarchical_clusters = [
-            HierarchicalCluster("1", 0, None, 0, False),
-            HierarchicalCluster("2", 0, None, 0, False),
-            HierarchicalCluster("3", 0, None, 0, False),
-            HierarchicalCluster("4", 1, None, 0, True),
-            HierarchicalCluster("5", 1, None, 0, True),
-            HierarchicalCluster("1", 2, 0, 1, True),
-            HierarchicalCluster("2", 2, 0, 1, True),
-            HierarchicalCluster("3", 3, 0, 1, True),
-        ]
+        hierarchical_clusters = HierarchicalClusters(
+            [
+                HierarchicalCluster("1", 0, None, 0, False),
+                HierarchicalCluster("2", 0, None, 0, False),
+                HierarchicalCluster("3", 0, None, 0, False),
+                HierarchicalCluster("4", 1, None, 0, True),
+                HierarchicalCluster("5", 1, None, 0, True),
+                HierarchicalCluster("1", 2, 0, 1, True),
+                HierarchicalCluster("2", 2, 0, 1, True),
+                HierarchicalCluster("3", 3, 0, 1, True),
+            ]
+        )
 
         expected = {
             "1": 2,
@@ -46,7 +58,7 @@ class TestHierarchicalCluster(unittest.TestCase):
         }
         self.assertEqual(
             expected,
-            HierarchicalCluster.final_hierarchical_clustering(hierarchical_clusters),
+            hierarchical_clusters.final_level_hierarchical_clustering(),
         )
 
 
@@ -79,7 +91,7 @@ class TestLeiden(unittest.TestCase):
         graph.add_edge("2", "3", weight=4.0)
 
         leiden(graph=graph, **good_args)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["starting_communities"] = 123
             leiden(graph=graph, **args)
@@ -88,7 +100,7 @@ class TestLeiden(unittest.TestCase):
         args["starting_communities"] = None
         leiden(graph=graph, **args)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["extra_forced_iterations"] = 1234.003
             leiden(graph=graph, **args)
@@ -98,7 +110,7 @@ class TestLeiden(unittest.TestCase):
             args["extra_forced_iterations"] = -4003
             leiden(graph=graph, **args)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["resolution"] = "leiden"
             leiden(graph=graph, **args)
@@ -108,7 +120,7 @@ class TestLeiden(unittest.TestCase):
             args["resolution"] = 0
             leiden(graph=graph, **args)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["randomness"] = "leiden"
             leiden(graph=graph, **args)
@@ -118,12 +130,12 @@ class TestLeiden(unittest.TestCase):
             args["randomness"] = 0
             leiden(graph=graph, **args)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["use_modularity"] = 1234
             leiden(graph=graph, **args)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["trials"] = "hotdog"
             leiden(graph=graph, **args)
@@ -139,7 +151,7 @@ class TestLeiden(unittest.TestCase):
         args["random_seed"] = None
         leiden(graph=graph, **args)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["random_seed"] = "leiden"
             leiden(graph=graph, **args)
@@ -149,23 +161,23 @@ class TestLeiden(unittest.TestCase):
             args["random_seed"] = -1
             leiden(graph=graph, **args)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["is_weighted"] = "leiden"
             leiden(graph=graph, **args)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["weight_default"] = "leiden"
             leiden(graph=graph, **args)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["check_directed"] = "leiden"
             leiden(graph=graph, **args)
 
         # one extra parameter hierarchical needs
-        with self.assertRaises(TypeError):
+        with self.assertRaises(BeartypeCallHintPepParamException):
             args = good_args.copy()
             args["max_cluster_size"] = "leiden"
             hierarchical_leiden(graph=graph, **args)
@@ -175,8 +187,10 @@ class TestLeiden(unittest.TestCase):
             args["max_cluster_size"] = 0
             hierarchical_leiden(graph=graph, **args)
 
+        cleared_partitions = good_args.copy()
+        del cleared_partitions["starting_communities"]
         as_csr = nx.to_scipy_sparse_matrix(graph)
-        partitions = leiden(graph=as_csr, **good_args)
+        partitions = leiden(graph=as_csr, **cleared_partitions)
         node_ids = partitions.keys()
         for node_id in node_ids:
             self.assertTrue(
@@ -193,7 +207,7 @@ class TestLeiden(unittest.TestCase):
 
         total_nodes = len([item for item in results if item.level == 0])
 
-        partitions = HierarchicalCluster.final_hierarchical_clustering(results)
+        partitions = results.final_level_hierarchical_clustering()
         self.assertEqual(total_nodes, len(partitions))
 
     # Github issue: 738
@@ -202,6 +216,17 @@ class TestLeiden(unittest.TestCase):
         partitions = leiden(graph)
         for node_id in partitions:
             self.assertTrue(isinstance(node_id, int))
+
+    # Github issue: 901
+    def test_hashable_nonstr_with_starting_communities(self):
+        seed = 1234
+        first_graph = nx.erdos_renyi_graph(20, 0.4, seed=seed)
+        second_graph = nx.erdos_renyi_graph(21, 0.4, seed=seed)
+        third_graph = nx.erdos_renyi_graph(19, 0.4, seed=seed)
+
+        first_partitions = leiden(first_graph)
+        second_partitions = leiden(second_graph, starting_communities=first_partitions)
+        third_partitions = leiden(third_graph, starting_communities=second_partitions)
 
 
 class TestLeidenIsolates(unittest.TestCase):
@@ -316,154 +341,109 @@ def add_edges_to_graph(graph: nx.Graph) -> nx.Graph:
 class TestValidEdgeList(unittest.TestCase):
     def test_empty_edge_list(self):
         edges = []
-        results = _validate_and_build_edge_list(
-            graph=edges,
-            is_weighted=True,
-            weight_attribute="weight",
-            check_directed=False,
-            weight_default=1.0,
+        results = _edge_list_to_edge_list(
+            edges=edges,
+            identifier=_IdentityMapper(),
         )
         self.assertEqual([], results[1])
 
     def test_assert_list_does_not_contain_tuples(self):
         edges = ["invalid"]
-        with self.assertRaisesRegex(TypeError, "list of tuples"):
-            _validate_and_build_edge_list(
-                graph=edges,
-                is_weighted=True,
-                weight_attribute="weight",
-                check_directed=False,
-                weight_default=1.0,
+        with self.assertRaises(BeartypeCallHintPepParamException):
+            _edge_list_to_edge_list(
+                edges=edges,
+                identifier=_IdentityMapper(),
             )
 
     def test_assert_list_contains_misshapen_tuple(self):
         edges = [(1, 2, 1.0, 1.0)]
-        with self.assertRaisesRegex(TypeError, "list of tuples"):
-            _validate_and_build_edge_list(
-                graph=edges,
-                is_weighted=True,
-                weight_attribute="weight",
-                check_directed=False,
-                weight_default=1.0,
+        with self.assertRaises(BeartypeCallHintPepParamException):
+            _edge_list_to_edge_list(
+                edges=edges,
+                identifier=_IdentityMapper(),
             )
 
     def test_assert_wrong_types_in_tuples(self):
         edges = [(True, 4, "sandwich")]
-        with self.assertRaises(ValueError):
-            _validate_and_build_edge_list(
-                graph=edges,
-                is_weighted=True,
-                weight_attribute="weight",
-                check_directed=False,
-                weight_default=1.0,
+        with self.assertRaises(BeartypeCallHintPepParamException):
+            _edge_list_to_edge_list(
+                edges=edges,
+                identifier=_IdentityMapper(),
             )
 
         edges = [(True, False, 3.2)]
-        results = _validate_and_build_edge_list(
-            graph=edges,
-            is_weighted=True,
-            weight_attribute="weight",
-            check_directed=False,
-            weight_default=1.0,
+        _nodes, results = _edge_list_to_edge_list(
+            edges=edges,
+            identifier=_IdentityMapper(),
         )
-        self.assertEqual([("True", "False", 3.2)], results[1])
+        self.assertEqual([("True", "False", 3.2)], results)
 
     def test_empty_nx(self):
-        expected = {}, []
-        results = _validate_and_build_edge_list(
+        expected = 0, []
+        results = _nx_to_edge_list(
             graph=nx.Graph(),
-            is_weighted=True,
+            identifier=_IdentityMapper(),
+            is_weighted=None,
             weight_attribute="weight",
-            check_directed=False,
             weight_default=1.0,
         )
         self.assertEqual(expected, results)
-        with self.assertRaises(TypeError):
-            _validate_and_build_edge_list(
+        with self.assertRaises(ValueError):
+            _nx_to_edge_list(
                 graph=nx.DiGraph(),
-                is_weighted=True,
+                identifier=_IdentityMapper(),
+                is_weighted=None,
                 weight_attribute="weight",
-                check_directed=False,
                 weight_default=1.0,
             )
-        with self.assertRaises(TypeError):
-            _validate_and_build_edge_list(
+        with self.assertRaises(ValueError):
+            _nx_to_edge_list(
                 graph=nx.MultiGraph(),
-                is_weighted=True,
+                identifier=_IdentityMapper(),
+                is_weighted=None,
                 weight_attribute="weight",
-                check_directed=False,
                 weight_default=1.0,
             )
-        with self.assertRaises(TypeError):
-            _validate_and_build_edge_list(
+        with self.assertRaises(ValueError):
+            _nx_to_edge_list(
                 graph=nx.MultiDiGraph(),
-                is_weighted=True,
+                identifier=_IdentityMapper(),
+                is_weighted=None,
                 weight_attribute="weight",
-                check_directed=False,
                 weight_default=1.0,
             )
 
     def test_valid_nx(self):
         graph = add_edges_to_graph(nx.Graph())
         expected = [("nick", "dwayne", 2.2), ("dwayne", "ben", 0.001)]
-        _, edges = _validate_and_build_edge_list(
+        _, edges = _nx_to_edge_list(
             graph=graph,
-            is_weighted=True,
+            identifier=_IdentityMapper(),
+            is_weighted=None,
             weight_attribute="weight",
-            check_directed=False,
             weight_default=1.0,
         )
         self.assertEqual(expected, edges)
-
-        with self.assertRaises(TypeError):
-            graph = add_edges_to_graph(nx.DiGraph())
-            _validate_and_build_edge_list(
-                graph=graph,
-                is_weighted=True,
-                weight_attribute="weight",
-                check_directed=False,
-                weight_default=1.0,
-            )
-
-        with self.assertRaises(TypeError):
-            graph = add_edges_to_graph(nx.MultiGraph())
-            _validate_and_build_edge_list(
-                graph=graph,
-                is_weighted=True,
-                weight_attribute="weight",
-                check_directed=False,
-                weight_default=1.0,
-            )
-
-        with self.assertRaises(TypeError):
-            graph = add_edges_to_graph(nx.MultiDiGraph())
-            _validate_and_build_edge_list(
-                graph=graph,
-                is_weighted=True,
-                weight_attribute="weight",
-                check_directed=False,
-                weight_default=1.0,
-            )
 
     def test_unweighted_nx(self):
         graph = nx.Graph()
         graph.add_edge("dwayne", "nick")
         graph.add_edge("nick", "ben")
 
-        with self.assertRaises(ValueError):
-            _validate_and_build_edge_list(
+        with self.assertRaises(TypeError):
+            _, edges = _nx_to_edge_list(
                 graph=graph,
+                identifier=_IdentityMapper(),
                 is_weighted=True,
                 weight_attribute="weight",
-                check_directed=False,
-                weight_default=None,
+                weight_default=1.0,
             )
 
-        _, edges = _validate_and_build_edge_list(
+        _, edges = _nx_to_edge_list(
             graph=graph,
-            is_weighted=True,
+            identifier=_IdentityMapper(),
+            is_weighted=False,
             weight_attribute="weight",
-            check_directed=False,
             weight_default=3.33333,
         )
         self.assertEqual(
@@ -472,11 +452,11 @@ class TestValidEdgeList(unittest.TestCase):
         )
 
         graph.add_edge("salad", "sandwich", weight=100)
-        _, edges = _validate_and_build_edge_list(
+        _, edges = _nx_to_edge_list(
             graph=graph,
-            is_weighted=True,
+            identifier=_IdentityMapper(),
+            is_weighted=False,
             weight_attribute="weight",
-            check_directed=False,
             weight_default=3.33333,
         )
         self.assertEqual(
@@ -499,110 +479,93 @@ class TestValidEdgeList(unittest.TestCase):
         sparse_directed = nx.to_scipy_sparse_matrix(di_graph)
 
         expected = [("0", "1", 2.2), ("1", "2", 0.001)]
-        _, edges = _validate_and_build_edge_list(
-            graph=dense_undirected,
-            is_weighted=True,
-            weight_attribute="weight",
+        _, edges = _adjacency_matrix_to_edge_list(
+            matrix=dense_undirected,
+            identifier=_IdentityMapper(),
             check_directed=True,
+            is_weighted=True,
             weight_default=1.0,
         )
         self.assertEqual(expected, edges)
-        _, edges = _validate_and_build_edge_list(
-            graph=sparse_undirected,
-            is_weighted=True,
-            weight_attribute="weight",
+        _, edges = _adjacency_matrix_to_edge_list(
+            matrix=sparse_undirected,
+            identifier=_IdentityMapper(),
             check_directed=True,
+            is_weighted=True,
             weight_default=1.0,
         )
         self.assertEqual(expected, edges)
 
         with self.assertRaises(ValueError):
-            _validate_and_build_edge_list(
-                graph=dense_directed,
-                is_weighted=True,
-                weight_attribute="weight",
+            _adjacency_matrix_to_edge_list(
+                matrix=dense_directed,
+                identifier=_IdentityMapper(),
                 check_directed=True,
+                is_weighted=True,
                 weight_default=1.0,
             )
 
         with self.assertRaises(ValueError):
-            _validate_and_build_edge_list(
-                graph=sparse_directed,
-                is_weighted=True,
-                weight_attribute="weight",
+            _adjacency_matrix_to_edge_list(
+                matrix=sparse_directed,
+                identifier=_IdentityMapper(),
                 check_directed=True,
+                is_weighted=True,
                 weight_default=1.0,
             )
 
     def test_empty_adj_matrices(self):
         dense = np.array([])
         with self.assertRaises(ValueError):
-            _validate_and_build_edge_list(
-                graph=dense,
-                is_weighted=True,
-                weight_attribute="weight",
+            _adjacency_matrix_to_edge_list(
+                matrix=dense,
+                identifier=_IdentityMapper(),
                 check_directed=True,
+                is_weighted=True,
                 weight_default=1.0,
             )
 
         sparse = scipy.sparse.csr_matrix([])
         with self.assertRaises(ValueError):
-            _validate_and_build_edge_list(
-                graph=sparse,
-                is_weighted=True,
-                weight_attribute="weight",
+            _adjacency_matrix_to_edge_list(
+                matrix=sparse,
+                identifier=_IdentityMapper(),
                 check_directed=True,
+                is_weighted=True,
                 weight_default=1.0,
             )
 
     def test_misshapen_matrices(self):
         data = [[3, 2, 0], [2, 0, 1]]  # this is utter gibberish
         with self.assertRaises(ValueError):
-            _validate_and_build_edge_list(
-                graph=np.array(data),
-                is_weighted=True,
-                weight_attribute="weight",
+            _adjacency_matrix_to_edge_list(
+                matrix=np.array(data),
+                identifier=_IdentityMapper(),
                 check_directed=True,
+                is_weighted=True,
                 weight_default=1.0,
             )
         with self.assertRaises(ValueError):
-            _validate_and_build_edge_list(
-                graph=scipy.sparse.csr_matrix(data),
-                is_weighted=True,
-                weight_attribute="weight",
+            _adjacency_matrix_to_edge_list(
+                matrix=scipy.sparse.csr_matrix(data),
+                identifier=_IdentityMapper(),
                 check_directed=True,
+                is_weighted=True,
                 weight_default=1.0,
-            )
-
-    def test_invalid_weight_default(self):
-        graph = nx.complete_graph(10)
-        with self.assertRaisesRegex(TypeError, "weight default"):
-            _validate_and_build_edge_list(
-                graph=graph,
-                is_weighted=True,
-                weight_attribute="weight",
-                check_directed=True,
-                weight_default="invalid",
             )
 
     def test_nx_graph_node_str_collision(self):
         graph = nx.Graph()
         graph.add_edge("1", 1, weight=1.0)
-        with self.assertRaisesRegex(ValueError, "representation collision"):
-            _validate_and_build_edge_list(
+        with self.assertRaisesRegex(ValueError, "collision"):
+            _nx_to_edge_list(
                 graph=graph,
+                identifier=_IdentityMapper(),
                 is_weighted=True,
                 weight_attribute="weight",
-                check_directed=True,
                 weight_default=1.0,
             )
 
     def test_edgelist_node_str_collision(self):
-        with self.assertRaisesRegex(ValueError, "representation collision"):
-            _validate_and_build_edge_list(
-                graph=[("1", 1, 1.0)],
-                is_weighted=True,
-                weight_attribute="weight",
-                check_directed=True,
-                weight_default=1.0,
-            )
+        with self.assertRaisesRegex(ValueError, "collision"):
+            _edge_list_to_edge_list(edges=[("1", 1, 1.0)], identifier=_IdentityMapper())


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes?
- [x] Does this PR add any new dependencies?
- [x] Does this PR modify any existing APIs?
   - [x] Is the change to the API backwards compatible?
- [x] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

Fixes #901

This PR kind of needs a bit of a history lesson.  Back in the day, when we first added this, all node ids had to be strings.

They had to be strings because it seemed easier to turn an int into a string than a string into an int (this is not necessarily true, but that *was* the thinking at the time).  And because we had to turn it into a string *somewhere*, we did it in Python, because nobody wants to try to make Rust carefully coerce Anything At All into Strings.  No one. 

So Rust expected a String id, and our python wrapper just said "hey, you guys know how to make other things into strings, you do it".  And then users said "but we don't want to, and why are integers so scary to you anyway", and we said "ok, that is fair I guess" and so we tried to get clever by converting all of the Object types provided to us in the various graph representation forms into Strings.  And it worked!  

We had a few bugs along the way like #756, but eventually we got it so that when you provided us a networkx Graph of integer node ids, you'd get it back, or an AdjacencyMatrix, or whatever; you expected integers that correspond to the node ids, not str(int), and so we complied.

But we ignored and forgot about doing the same action for the starting_communities, because ... we just missed it.  And by we, I distinctly mean **I**.

And so it went for a while until one of our users was using timeseries graphs and using the previous month's communities to jump start the next month's community detection with leiden.  And they had int ids.  And they took their returned map of int node_ids -> communities and tried to hand it right back to us.

Now, the problem there is that we took their node ids, converted them into strings, gave them to rust, converted them back to the original objects, and used those objects in the dictionary we were returning the user - because the user isn't going to want str(int) as the key in their dictionary when their node ids are ints, remember?

But now we have a problem, because the starting_communities very explicitly want node_ids that are strings, and we didn't map them, because, again, you can do that, right?  And we forgot that we said we were going to do that.  And again, by we, I mean very distinctly **I**.  

So this PR fixes that.  Thank you for coming to Story time with Dax.

