### PR TITLE
Allow for arbitrarily indexed node_data in networkplot

### DIFF
--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -753,7 +753,11 @@ def _plot_ellipse_and_data(
         angle = np.arctan(u[1] / u[0])
         angle = 180.0 * angle / np.pi
         ell = mpl.patches.Ellipse(
-            [mean[j], mean[k]], v[0], v[1], 180.0 + angle, color=cluster_palette[i],
+            [mean[j], mean[k]], 
+            v[0],
+            v[1],
+            180.0 + angle,
+            color=cluster_palette[i],
         )
         ell.set_clip_box(ax.bbox)
         ell.set_alpha(alpha)
@@ -969,7 +973,10 @@ def pairplot_with_gmm(
         else:
             handles, labels = axes[1].get_legend_handles_labels()
         fig.legend(
-            handles, labels, loc="center right", title=legend_name,
+            handles,
+            labels,
+            loc="center right",
+            title=legend_name,
         )
         # allows for the legend to not overlap with plots while also keeping
         # legend in frame

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -1319,6 +1319,7 @@ def networkplot(
                 "If x and y are strings, node_data must be pandas DataFrame."
             )
         plot_df = node_data.copy()
+        plot_df = plot_df.reset_index(drop=True)
         x_key = x
         y_key = y
         if node_hue is not None:

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -753,11 +753,7 @@ def _plot_ellipse_and_data(
         angle = np.arctan(u[1] / u[0])
         angle = 180.0 * angle / np.pi
         ell = mpl.patches.Ellipse(
-            [mean[j], mean[k]],
-            v[0],
-            v[1],
-            180.0 + angle,
-            color=cluster_palette[i],
+            [mean[j], mean[k]], v[0], v[1], 180.0 + angle, color=cluster_palette[i],
         )
         ell.set_clip_box(ax.bbox)
         ell.set_alpha(alpha)
@@ -973,10 +969,7 @@ def pairplot_with_gmm(
         else:
             handles, labels = axes[1].get_legend_handles_labels()
         fig.legend(
-            handles,
-            labels,
-            loc="center right",
-            title=legend_name,
+            handles, labels, loc="center right", title=legend_name,
         )
         # allows for the legend to not overlap with plots while also keeping
         # legend in frame

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -753,7 +753,7 @@ def _plot_ellipse_and_data(
         angle = np.arctan(u[1] / u[0])
         angle = 180.0 * angle / np.pi
         ell = mpl.patches.Ellipse(
-            [mean[j], mean[k]], 
+            [mean[j], mean[k]],
             v[0],
             v[1],
             180.0 + angle,

--- a/mypi.ini
+++ b/mypi.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/tests/test_n2v.py
+++ b/tests/test_n2v.py
@@ -1,0 +1,183 @@
+# Copyright (c) Microsoft Corporation and contributors.
+# Licensed under the MIT License.
+
+import unittest
+import networkx as nx
+import numpy as np
+import graspologic.embed.n2v as n2v
+from graspologic.embed.n2v import _Node2VecGraph
+
+
+class Node2VecEmbedTest(unittest.TestCase):
+    def test_node2vec_embedding_correct_shape_is_returned(self):
+        import io
+
+        graph = nx.read_edgelist(
+            io.StringIO(_edge_list), nodetype=int, create_using=nx.DiGraph()
+        )
+
+        model = n2v.node2vec_embed(graph)
+        model_matrix: np.ndarray = model[0]
+        vocab_list = model[1]
+        self.assertIsNotNone(model)
+        self.assertIsNotNone(model[0])
+        self.assertIsNotNone(model[1])
+
+        # model matrix should be 34 x 128
+        self.assertEqual(model_matrix.shape[0], 34)
+        self.assertEqual(model_matrix.shape[1], 128)
+
+        # vocab list should have exactly 34 elements
+        self.assertEqual(len(vocab_list), 34)
+
+    def test_node2vec_embedding_florentine_graph_correct_shape_is_returned(self):
+        graph = nx.florentine_families_graph()
+        for s, t in graph.edges():
+            graph.add_edge(s, t, weight=1)
+
+        model = n2v.node2vec_embed(graph)
+        model_matrix: np.ndarray = model[0]
+        vocab_list = model[1]
+        self.assertIsNotNone(model)
+        self.assertIsNotNone(model[0])
+        self.assertIsNotNone(model[1])
+
+        # model matrix should be 34 x 128
+        self.assertEqual(model_matrix.shape[0], 15)
+        self.assertEqual(model_matrix.shape[1], 128)
+
+        # vocab list should have exactly 34 elements
+        self.assertEqual(len(vocab_list), 15)
+
+    def test_node2vec_embedding_barbell_graph_correct_shape_is_returned(self):
+        graph = nx.barbell_graph(25, 2)
+        for s, t in graph.edges():
+            graph.add_edge(s, t, weight=1)
+
+        model = n2v.node2vec_embed(graph)
+        model_matrix: np.ndarray = model[0]
+        vocab_list = model[1]
+        self.assertIsNotNone(model)
+        self.assertIsNotNone(model[0])
+        self.assertIsNotNone(model[1])
+
+        # model matrix should be 34 x 128
+        self.assertEqual(model_matrix.shape[0], 52)
+        self.assertEqual(model_matrix.shape[1], 128)
+
+        # vocab list should have exactly 34 elements
+        self.assertEqual(len(vocab_list), 52)
+
+    def test_get_walk_length_lower_defaults_to_1(self):
+        expected_walk_length = 1
+
+        g = _Node2VecGraph(nx.Graph(), 1, 1)
+        w = g._get_walk_length_interpolated(
+            degree=0, percentiles=[1, 2, 3, 4, 10, 100], max_walk_length=10
+        )
+
+        self.assertEqual(w, expected_walk_length)
+
+    def test_get_walk_length_higher_default_to_walk_length(self):
+        expected_walk_length = 100
+
+        g = _Node2VecGraph(nx.Graph(), 1, 1)
+        w = g._get_walk_length_interpolated(
+            degree=10,
+            percentiles=[2, 3, 4, 5, 6, 7, 8, 9],
+            max_walk_length=expected_walk_length,
+        )
+
+        self.assertEqual(w, expected_walk_length)
+
+    def test_get_walk_length_in_middle_selects_interpolated_bucket(self):
+        expected_walk_length = 5
+
+        g = _Node2VecGraph(nx.Graph(), 1, 1)
+        w = g._get_walk_length_interpolated(
+            degree=5, percentiles=[2, 3, 4, 5, 6, 7, 8, 9], max_walk_length=10
+        )
+
+        self.assertEqual(w, expected_walk_length)
+
+
+_edge_list = """
+1 32
+1 22
+1 20
+1 18
+1 14
+1 13
+1 12
+1 11
+1 9
+1 8
+1 7
+1 6
+1 5
+1 4
+1 3
+1 2
+2 31
+2 22
+2 20
+2 18
+2 14
+2 8
+2 4
+2 3
+3 14
+3 9
+3 10
+3 33
+3 29
+3 28
+3 8
+3 4
+4 14
+4 13
+4 8
+5 11
+5 7
+6 17
+6 11
+6 7
+7 17
+9 34
+9 33
+9 33
+10 34
+14 34
+15 34
+15 33
+16 34
+16 33
+19 34
+19 33
+20 34
+21 34
+21 33
+23 34
+23 33
+24 30
+24 34
+24 33
+24 28
+24 26
+25 32
+25 28
+25 26
+26 32
+27 34
+27 30
+28 34
+29 34
+29 32
+30 34
+30 33
+31 34
+31 33
+32 34
+32 33
+33 34
+"""

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -365,7 +365,7 @@ class TestPlot(unittest.TestCase):
 
     def test_networkplot_outputs_str(self):
         X = er_np(15, 0.7)
-        node_df = pd.DataFrame(index=['node {}'.format(i) for i in range(15)])
+        node_df = pd.DataFrame(index=["node {}".format(i) for i in range(15)])
         node_df.loc[:, "source"] = np.random.rand(15, 1)
         node_df.loc[:, "target"] = np.random.rand(15, 1)
         node_df.loc[:, "hue"] = np.random.randint(2, size=15)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -184,7 +184,6 @@ class TestPlot(unittest.TestCase):
         fig = heatmap(
             X, transform="log", xticklabels=xticklabels, yticklabels=yticklabels
         )
-        fig = heatmap(X, transform="zero-boost")
         fig = heatmap(X, transform="simple-all")
         fig = heatmap(X, transform="simple-nonzero")
         fig = heatmap(X, transform="binarize")
@@ -280,7 +279,7 @@ class TestPlot(unittest.TestCase):
         _test_pairplot_with_gmm_outputs(covariance_type="spherical")
 
     def test_networkplot_inputs(self):
-        X = np.random.rand(15, 3)
+        X = er_np(15, 0.5)
         x = np.random.rand(15, 1)
         y = np.random.rand(15, 1)
         with self.assertRaises(beartype.roar.BeartypeCallHintPepParamException):
@@ -328,8 +327,8 @@ class TestPlot(unittest.TestCase):
             with self.assertRaises(TypeError):
                 networkplot(adjacency=X, x=x, y=y, legend=4)
 
-    def test_networkplot_outputs(self):
-        X = np.random.rand(15, 3)
+    def test_networkplot_outputs_int(self):
+        X = er_np(15, 0.5)
         xarray = np.random.rand(15, 1)
         yarray = np.random.rand(15, 1)
         xstring = "source"
@@ -362,6 +361,30 @@ class TestPlot(unittest.TestCase):
             edge_alpha=0.4,
             edge_linewidth=0.6,
             ax=ax,
+        )
+
+    def test_networkplot_outputs_str(self):
+        X = er_np(15, 0.7)
+        node_df = pd.DataFrame(index=['node {}'.format(i) for i in range(15)])
+        node_df.loc[:, "source"] = np.random.rand(15, 1)
+        node_df.loc[:, "target"] = np.random.rand(15, 1)
+        node_df.loc[:, "hue"] = np.random.randint(2, size=15)
+        palette = {0: (0.8, 0.4, 0.2), 1: (0, 0.9, 0.4)}
+        size = np.random.rand(15)
+        sizes = (10, 200)
+
+        fig = networkplot(
+            adjacency=X,
+            x="source",
+            y="target",
+            node_data=node_df,
+            node_hue="hue",
+            palette=palette,
+            node_size=size,
+            node_sizes=sizes,
+            node_alpha=0.5,
+            edge_alpha=0.4,
+            edge_linewidth=0.6,
         )
 
     def test_sort_inds(self):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #896.

#### What does this implement/fix? Briefly explain your changes.
Resets index of ``node_data`` so that ``networkplot`` works with an arbitrarily indexed dataframe.

#### Any other comments?
