### PR TITLE
1.0.0 prep and dependency adjustments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: ["3.7", "3.8", "3.9", "3.10"]
+        python_version: ["3.7", "3.8", "3.9"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: [3.6, 3.7, 3.8, 3.9]
+        python_version: [3.7, 3.8, 3.9, 3.10]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: [3.7, 3.8, 3.9, 3.10]
+        python_version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ Please visit the [tutorial section](https://microsoft.github.io/graspologic/late
 - macOS x64
 - Windows 10 x64
 
-And across the following versions of Python:
-- 3.6 (x64)
-- 3.7 (x64)
-- 3.8 (x64)
+And across the following **x86_64** versions of Python:
+- 3.7
+- 3.8
+- 3.9
+- 3.10
 
 If you try to use `graspologic` for a different platform than the ones listed and notice any unexpected behavior,
 please feel free to [raise an issue](https://github.com/microsoft/graspologic/issues/new).  It's better for ourselves and our users

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ And across the following **x86_64** versions of Python:
 - 3.7
 - 3.8
 - 3.9
-- 3.10
 
 If you try to use `graspologic` for a different platform than the ones listed and notice any unexpected behavior,
 please feel free to [raise an issue](https://github.com/microsoft/graspologic/issues/new).  It's better for ourselves and our users

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,8 +63,15 @@ autosummary_generate = True
 
 # -- sphinx.ext.autodoc
 autoclass_content = "both"
-autodoc_default_flags = ["members", "inherited-members"]
-autodoc_member_order = "bysource"  # default is alphabetical
+autodoc_default_options = {
+    'members': True,
+    'inherited-members': True,
+    'member-order': 'bysource',
+    'special-members': '__init__',
+    'undoc-members': True,
+}
+autodoc_class_signature = "separated"
+autodoc_typehints = "description"
 
 # -- sphinx.ext.intersphinx
 intersphinx_mapping = {

--- a/docs/reference/reference/cluster.rst
+++ b/docs/reference/reference/cluster.rst
@@ -17,3 +17,4 @@ Gaussian Mixture Models Clustering
 Hierarchical Clustering
 ----------------------------------
 .. autoclass:: DivisiveCluster
+    :no-inherited-members:

--- a/docs/reference/release.rst
+++ b/docs/reference/release.rst
@@ -6,7 +6,7 @@ Release Log
 graspologic 1.0.0
 -----------------
 - Removed Python 3.6 support
-- Officially added Python 3.9 and 3.10 support
+- Officially added Python 3.9 support
 - Fixed a type in an error message 
   `#904 <https://github.com/microsoft/graspologic/pull/904>`
 - Added support for arbitrarily indexed node data for networkplot 

--- a/docs/reference/release.rst
+++ b/docs/reference/release.rst
@@ -5,6 +5,8 @@ Release Log
 
 graspologic 1.0.0
 -----------------
+- Removed Python 3.6 support
+- Officially added Python 3.9 and 3.10 support
 - Fixed a type in an error message 
   `#904 <https://github.com/microsoft/graspologic/pull/904>`
 - Added support for arbitrarily indexed node data for networkplot 

--- a/graspologic/embed/ase.py
+++ b/graspologic/embed/ase.py
@@ -70,7 +70,6 @@ class AdjacencySpectralEmbed(BaseSpectralEmbed):
         randomized svd solver for deterministic, albeit pseudo-randomized behavior.
 
 
-
     Attributes
     ----------
     n_features_in_: int

--- a/graspologic/embed/base.py
+++ b/graspologic/embed/base.py
@@ -247,8 +247,10 @@ class BaseSpectralEmbed(BaseEstimator):
     def transform(self, X):  # type: ignore
         """
         Obtain latent positions from an adjacency matrix or matrix of out-of-sample
-        vertices. For more details on transforming out-of-sample vertices, see the
-        :ref:`tutorials <embed_tutorials>`. For mathematical background, see [2].
+        vertices. For more details on transforming out-of-sample vertices, see `Out-of-Sample (OOS) Embedding
+        <https://microsoft.github.io/graspologic/latest/tutorials/embedding/OutOfSampleEmbed.html>`_
+
+        For mathematical background, see [2].
 
         Parameters
         ----------
@@ -293,8 +295,8 @@ class BaseSpectralEmbed(BaseEstimator):
         References
         ----------
         .. [1] Sussman, D.L., Tang, M., Fishkind, D.E., Priebe, C.E.  "A
-        Consistent Adjacency Spectral Embedding for Stochastic Blockmodel Graphs,"
-        Journal of the American Statistical Association, Vol. 107(499), 2012
+            Consistent Adjacency Spectral Embedding for Stochastic Blockmodel Graphs,"
+            Journal of the American Statistical Association, Vol. 107(499), 2012
 
         .. [2] Levin, K., Roosta-Khorasani, F., Mahoney, M. W., & Priebe, C. E. (2018).
             Out-of-sample extension of graph adjacency spectral embedding. PMLR: Proceedings

--- a/graspologic/inference/latent_distribution_test.py
+++ b/graspologic/inference/latent_distribution_test.py
@@ -203,7 +203,7 @@ def latent_distribution_test(
             d must be same. n_components attribute is ignored in this case.
 
     Returns
-    ----------
+    -------
     stat : float
         The observed difference between the embedded latent positions of the
         two input graphs.

--- a/graspologic/inference/latent_position_test.py
+++ b/graspologic/inference/latent_position_test.py
@@ -88,7 +88,7 @@ def latent_position_test(
         Supply -1 to use all cores available.
 
     Returns
-    ----------
+    -------
     stat : float
         The observed difference between the embedded positions of the two input graphs
         after an alignment (the type of alignment depends on ``test_case``)

--- a/graspologic/partition/leiden.py
+++ b/graspologic/partition/leiden.py
@@ -274,7 +274,7 @@ def leiden(
     ------
     ValueError
     TypeError
-    BeartypeCallHintPepParamException
+    BeartypeCallHintParamViolation
 
     See Also
     --------
@@ -539,7 +539,7 @@ def hierarchical_leiden(
     ------
     ValueError
     TypeError
-    BeartypeCallHintPepParamException
+    BeartypeCallHintParamViolation
 
     See Also
     --------

--- a/graspologic/pipeline/embed/adjacency_spectral_embedding.py
+++ b/graspologic/pipeline/embed/adjacency_spectral_embedding.py
@@ -106,7 +106,7 @@ def adjacency_spectral_embedding(
 
     Raises
     ------
-    beartype.roar.BeartypeCallHintPepParamException if parameters do not match type hints
+    beartype.roar.BeartypeCallHintParamViolation if parameters do not match type hints
     ValueError if values are not within appropriate ranges or allowed values
 
     See Also

--- a/graspologic/pipeline/embed/embeddings.py
+++ b/graspologic/pipeline/embed/embeddings.py
@@ -56,7 +56,7 @@ class Embeddings:
 
         Raises
         ------
-        beartype.roar.BeartypeCallHintPepParamException if the types are invalid
+        beartype.roar.BeartypeCallHintParamViolation if the types are invalid
         ValueError if the row count of labels does not equal the row count of embeddings
         """
         if labels.shape[0] != embeddings.shape[0]:

--- a/graspologic/pipeline/embed/laplacian_spectral_embedding.py
+++ b/graspologic/pipeline/embed/laplacian_spectral_embedding.py
@@ -109,7 +109,7 @@ def laplacian_spectral_embedding(
 
     Raises
     ------
-    beartype.roar.BeartypeCallHintPepParamException if parameters do not match type hints
+    beartype.roar.BeartypeCallHintParamViolation if parameters do not match type hints
     ValueError if values are not within appropriate ranges or allowed values
 
     See Also

--- a/graspologic/pipeline/embed/omnibus_embedding.py
+++ b/graspologic/pipeline/embed/omnibus_embedding.py
@@ -107,7 +107,7 @@ def omnibus_embedding_pairwise(
 
     Raises
     ------
-    beartype.roar.BeartypeCallHintPepParamException if parameters do not match type hints
+    beartype.roar.BeartypeCallHintParamViolation if parameters do not match type hints
     ValueError if values are not within appropriate ranges or allowed values
 
     See Also

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools >= 24.2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     POT>=0.7.0
     seaborn>= 0.11.0
     scikit-learn>=0.22.0
-    scipy>=1.4.0
+    scipy>=1.4.0,<1.8.0 # restricted due to hyppo 0.2.2 bug
     umap-learn>=0.4.6
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     matplotlib>=3.0.0,!=3.3.*
     networkx>=2.1
     numpy>=1.8.1
-    POT>=0.7.0
+    POT>=0.7.0,<0.8.1  # 0.8.1 drops python 3.6 support
     seaborn>= 0.11.0
     scikit-learn>=0.22.0
     scipy>=1.4.0,<1.8.0 # restricted due to hyppo 0.2.2 bug

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
     Topic :: Scientific/Engineering :: Mathematics
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -26,9 +25,10 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
+python_requires = >=3.7, <3.11
 install_requires =
     anytree>=2.8.0
-    beartype>=0.9.0
+    beartype>=0.10.0
     gensim>=4.0.0
     graspologic-native>=1.1.1
     hyppo>=0.2.2
@@ -36,7 +36,7 @@ install_requires =
     matplotlib>=3.0.0,!=3.3.*
     networkx>=2.1
     numpy>=1.8.1
-    POT>=0.7.0,<0.8.1  # 0.8.1 drops python 3.6 support
+    POT>=0.7.0
     seaborn>= 0.11.0
     scikit-learn>=0.22.0
     scipy>=1.4.0,<1.8.0 # restricted due to hyppo 0.2.2 bug

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     beartype>=0.10.0
     gensim>=4.0.0
     graspologic-native>=1.1.1
-    hyppo>=0.2.2
+    hyppo>=0.3.0
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,!=3.3.*
     networkx>=2.1
@@ -38,7 +38,7 @@ install_requires =
     POT>=0.7.0
     seaborn>= 0.11.0
     scikit-learn>=0.22.0
-    scipy>=1.4.0,<1.8.0 # restricted due to hyppo 0.2.2 bug
+    scipy>=1.4.0
     umap-learn>=0.4.6
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,10 @@ include_package_data = True
 python_requires = >=3.7, <3.10
 install_requires =
     anytree>=2.8.0
-    beartype>=0.10.0
+    beartype>=0.10.0 
     gensim>=4.0.0
     graspologic-native>=1.1.1
-    hyppo>=0.3.1
+    hyppo>=0.3.2 # bug with lower versions and scipy>=1.8
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,!=3.3.*
     networkx>=2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     beartype>=0.10.0
     gensim>=4.0.0
     graspologic-native>=1.1.1
-    hyppo>=0.3.0
+    hyppo>=0.3.1
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,!=3.3.*
     networkx>=2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,12 +20,11 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
 
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.7, <3.11
+python_requires = >=3.7, <3.10
 install_requires =
     anytree>=2.8.0
     beartype>=0.10.0

--- a/tests/partition/test_leiden.py
+++ b/tests/partition/test_leiden.py
@@ -8,7 +8,7 @@ import networkx as nx
 import numpy as np
 import pytest
 import scipy
-from beartype.roar import BeartypeCallHintPepParamException
+from beartype.roar import BeartypeCallHintParamViolation
 
 from graspologic.partition import (
     HierarchicalCluster,
@@ -91,7 +91,7 @@ class TestLeiden(unittest.TestCase):
         graph.add_edge("2", "3", weight=4.0)
 
         leiden(graph=graph, **good_args)
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["starting_communities"] = 123
             leiden(graph=graph, **args)
@@ -100,7 +100,7 @@ class TestLeiden(unittest.TestCase):
         args["starting_communities"] = None
         leiden(graph=graph, **args)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["extra_forced_iterations"] = 1234.003
             leiden(graph=graph, **args)
@@ -110,7 +110,7 @@ class TestLeiden(unittest.TestCase):
             args["extra_forced_iterations"] = -4003
             leiden(graph=graph, **args)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["resolution"] = "leiden"
             leiden(graph=graph, **args)
@@ -120,7 +120,7 @@ class TestLeiden(unittest.TestCase):
             args["resolution"] = 0
             leiden(graph=graph, **args)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["randomness"] = "leiden"
             leiden(graph=graph, **args)
@@ -130,12 +130,12 @@ class TestLeiden(unittest.TestCase):
             args["randomness"] = 0
             leiden(graph=graph, **args)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["use_modularity"] = 1234
             leiden(graph=graph, **args)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["trials"] = "hotdog"
             leiden(graph=graph, **args)
@@ -151,7 +151,7 @@ class TestLeiden(unittest.TestCase):
         args["random_seed"] = None
         leiden(graph=graph, **args)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["random_seed"] = "leiden"
             leiden(graph=graph, **args)
@@ -161,23 +161,23 @@ class TestLeiden(unittest.TestCase):
             args["random_seed"] = -1
             leiden(graph=graph, **args)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["is_weighted"] = "leiden"
             leiden(graph=graph, **args)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["weight_default"] = "leiden"
             leiden(graph=graph, **args)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["check_directed"] = "leiden"
             leiden(graph=graph, **args)
 
         # one extra parameter hierarchical needs
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             args = good_args.copy()
             args["max_cluster_size"] = "leiden"
             hierarchical_leiden(graph=graph, **args)
@@ -349,7 +349,7 @@ class TestValidEdgeList(unittest.TestCase):
 
     def test_assert_list_does_not_contain_tuples(self):
         edges = ["invalid"]
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             _edge_list_to_edge_list(
                 edges=edges,
                 identifier=_IdentityMapper(),
@@ -357,7 +357,7 @@ class TestValidEdgeList(unittest.TestCase):
 
     def test_assert_list_contains_misshapen_tuple(self):
         edges = [(1, 2, 1.0, 1.0)]
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             _edge_list_to_edge_list(
                 edges=edges,
                 identifier=_IdentityMapper(),
@@ -365,7 +365,7 @@ class TestValidEdgeList(unittest.TestCase):
 
     def test_assert_wrong_types_in_tuples(self):
         edges = [(True, 4, "sandwich")]
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             _edge_list_to_edge_list(
                 edges=edges,
                 identifier=_IdentityMapper(),

--- a/tests/pipeline/embed/test_adjacency_spectral_embedding.py
+++ b/tests/pipeline/embed/test_adjacency_spectral_embedding.py
@@ -6,7 +6,7 @@ import unittest
 import networkx as nx
 import numpy as np
 import pytest
-from beartype.roar import BeartypeCallHintPepParamException
+from beartype.roar import BeartypeCallHintParamViolation
 
 import graspologic.utils
 from graspologic.embed import AdjacencySpectralEmbed
@@ -44,7 +44,7 @@ class TestAdjacencySpectralEmbedding(unittest.TestCase):
 
     def test_argument_validation(self):
         # graph types
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             adjacency_spectral_embedding(
                 graph=np.array([[1, 2], [2, 1]]), **self.default_parameters
             )
@@ -56,7 +56,7 @@ class TestAdjacencySpectralEmbedding(unittest.TestCase):
         # dimensions
         dimensions = [None, 1.3, "1"]
         for dimension in dimensions:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = TestAdjacencySpectralEmbedding.parameters()
                 params["dimensions"] = dimension
                 params["graph"] = self.graph
@@ -65,19 +65,19 @@ class TestAdjacencySpectralEmbedding(unittest.TestCase):
         # elbow_cuts
         elbow_cuts = ["3", 1.3]
         for elbow_cut in elbow_cuts:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = TestAdjacencySpectralEmbedding.parameters()
                 params["elbow_cut"] = elbow_cut
                 params["graph"] = self.graph
                 adjacency_spectral_embedding(**params)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             params = TestAdjacencySpectralEmbedding.parameters()
             params["svd_solver_algorithm"] = 1
             params["graph"] = self.graph
             adjacency_spectral_embedding(**params)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             params = TestAdjacencySpectralEmbedding.parameters()
             params["svd_solver_algorithm"] = "sandwich"
             params["graph"] = self.graph
@@ -86,7 +86,7 @@ class TestAdjacencySpectralEmbedding(unittest.TestCase):
         # svd_solver_iterations
         svd_solver_iterations = [None, "5", 5.1]
         for ssi in svd_solver_iterations:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = TestAdjacencySpectralEmbedding.parameters()
                 params["svd_solver_iterations"] = ssi
                 params["graph"] = self.graph
@@ -95,7 +95,7 @@ class TestAdjacencySpectralEmbedding(unittest.TestCase):
         # svd_seed
         svd_seeds = ["5", 5.1]
         for svd_seed in svd_seeds:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = TestAdjacencySpectralEmbedding.parameters()
                 params["svd_seed"] = svd_seed
                 params["graph"] = self.graph

--- a/tests/pipeline/embed/test_embeddings.py
+++ b/tests/pipeline/embed/test_embeddings.py
@@ -4,7 +4,7 @@
 import unittest
 
 import numpy as np
-from beartype.roar import BeartypeCallHintPepParamException
+from beartype.roar import BeartypeCallHintParamViolation
 
 from graspologic.pipeline.embed import Embeddings
 
@@ -46,11 +46,11 @@ class TestEmbeddings(unittest.TestCase):
             np.testing.assert_array_equal(expected[key], view[key])
 
     def test_argument_types(self):
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             Embeddings(None, None)
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             Embeddings(np.array(["hello"]), None)
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             Embeddings(["hello"], [1.0])
         with self.assertRaises(ValueError):
             Embeddings(np.array(["hello"]), np.array([[1.1, 1.2], [2.1, 2.2]]))

--- a/tests/pipeline/embed/test_laplacian_spectral_embedding.py
+++ b/tests/pipeline/embed/test_laplacian_spectral_embedding.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 import networkx as nx
 import numpy as np
 import pytest
-from beartype.roar import BeartypeCallHintPepParamException
+from beartype.roar import BeartypeCallHintParamViolation
 
 import graspologic.utils
 from graspologic.embed import LaplacianSpectralEmbed
@@ -43,7 +43,7 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
 
     def test_argument_validation(self):
         # graph types
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             params = TestLaplacianSpectralEmbedding.parameters()
             params["graph"] = np.array([[1, 2], [2, 1]])
             laplacian_spectral_embedding(**params)
@@ -55,7 +55,7 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
         # dimensions
         dimensions = [None, 1.3, "1"]
         for dimension in dimensions:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = TestLaplacianSpectralEmbedding.parameters(self.graph)
                 params["dimensions"] = dimension
                 laplacian_spectral_embedding(**params)
@@ -63,17 +63,17 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
         # elbow_cuts
         elbow_cuts = ["3", 1.3]
         for elbow_cut in elbow_cuts:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = TestLaplacianSpectralEmbedding.parameters(self.graph)
                 params["elbow_cut"] = elbow_cut
                 laplacian_spectral_embedding(**params)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             params = TestLaplacianSpectralEmbedding.parameters(self.graph)
             params["svd_solver_algorithm"] = 1
             laplacian_spectral_embedding(**params)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             params = TestLaplacianSpectralEmbedding.parameters(self.graph)
             params["svd_solver_algorithm"] = "sandwich"
             laplacian_spectral_embedding(**params)
@@ -81,7 +81,7 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
         # svd_solver_iterations
         svd_solver_iterations = [None, "5", 5.1]
         for ssi in svd_solver_iterations:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = TestLaplacianSpectralEmbedding.parameters(self.graph)
                 params["svd_solver_iterations"] = ssi
                 laplacian_spectral_embedding(**params)
@@ -89,7 +89,7 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
         # svd_seed
         svd_seeds = ["5", 5.1]
         for svd_seed in svd_seeds:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = TestLaplacianSpectralEmbedding.parameters(self.graph)
                 params["svd_seed"] = svd_seed
                 laplacian_spectral_embedding(**params)
@@ -97,17 +97,17 @@ class TestLaplacianSpectralEmbedding(unittest.TestCase):
         # form
         forms = [0, None]
         for form in forms:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = TestLaplacianSpectralEmbedding.parameters(self.graph)
                 params["form"] = form
                 laplacian_spectral_embedding(**params)
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             params = TestLaplacianSpectralEmbedding.parameters(self.graph)
             params["form"] = "formless"
             laplacian_spectral_embedding(**params)
 
         # regularizer
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             params = TestLaplacianSpectralEmbedding.parameters(self.graph)
             params["regularizer"] = "1"
             laplacian_spectral_embedding(**params)

--- a/tests/pipeline/embed/test_omnibus_embedding.py
+++ b/tests/pipeline/embed/test_omnibus_embedding.py
@@ -5,7 +5,7 @@ import unittest
 
 import networkx as nx
 import numpy as np
-from beartype.roar import BeartypeCallHintPepParamException
+from beartype.roar import BeartypeCallHintParamViolation
 
 from graspologic.pipeline.embed import omnibus_embedding_pairwise
 
@@ -24,7 +24,7 @@ class TestOmnibusEmbedding(unittest.TestCase):
         }
 
     def test_argument_validation(self):
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             omnibus_embedding_pairwise(graphs=[1])
 
         with self.assertRaises(ValueError):
@@ -35,7 +35,7 @@ class TestOmnibusEmbedding(unittest.TestCase):
         # dimensions
         dimensions = [None, 1.3, "1"]
         for dimension in dimensions:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = self._default_parameters()
                 params["dimensions"] = dimension
                 params["graphs"] = self.graphs
@@ -44,19 +44,19 @@ class TestOmnibusEmbedding(unittest.TestCase):
         # elbow_cuts
         elbow_cuts = ["3", 1.3]
         for elbow_cut in elbow_cuts:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = self._default_parameters()
                 params["elbow_cut"] = elbow_cut
                 params["graphs"] = self.graphs
                 omnibus_embedding_pairwise(**params)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             params = self._default_parameters()
             params["svd_solver_algorithm"] = 1
             params["graphs"] = self.graphs
             omnibus_embedding_pairwise(**params)
 
-        with self.assertRaises(BeartypeCallHintPepParamException):
+        with self.assertRaises(BeartypeCallHintParamViolation):
             params = self._default_parameters()
             params["svd_solver_algorithm"] = "sandwich"
             params["graphs"] = self.graphs
@@ -65,7 +65,7 @@ class TestOmnibusEmbedding(unittest.TestCase):
         # svd_solver_iterations
         svd_solver_iterations = [None, "5", 5.1]
         for ssi in svd_solver_iterations:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = self._default_parameters()
                 params["svd_solver_iterations"] = ssi
                 params["graphs"] = self.graphs
@@ -74,7 +74,7 @@ class TestOmnibusEmbedding(unittest.TestCase):
         # svd_seed
         svd_seeds = ["5", 5.1]
         for svd_seed in svd_seeds:
-            with self.assertRaises(BeartypeCallHintPepParamException):
+            with self.assertRaises(BeartypeCallHintParamViolation):
                 params = self._default_parameters()
                 params["svd_seed"] = svd_seed
                 params["graphs"] = self.graphs

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -63,7 +63,7 @@ class TestPlot(unittest.TestCase):
         figsize = "bad figsize"
         with self.assertRaises(TypeError):
             heatmap(X, figsize=figsize)
-        with self.assertRaises(beartype.roar.BeartypeCallHintPepParamException):
+        with self.assertRaises(beartype.roar.BeartypeCallHintParamViolation):
             with self.assertRaises(TypeError):
                 networkplot(adjacency=X, x=x, y=y, figsize=figsize)
 
@@ -82,7 +82,7 @@ class TestPlot(unittest.TestCase):
             gridplot([X], grid_labels, title=title)
         with self.assertRaises(TypeError):
             pairplot(X, title=title)
-        with self.assertRaises(beartype.roar.BeartypeCallHintPepParamException):
+        with self.assertRaises(beartype.roar.BeartypeCallHintParamViolation):
             with self.assertRaises(TypeError):
                 networkplot(adjacency=X, x=x, y=y, title=title)
 
@@ -94,7 +94,7 @@ class TestPlot(unittest.TestCase):
             gridplot([X], grid_labels, context=context)
         with self.assertRaises(TypeError):
             pairplot(X, context=context)
-        with self.assertRaises(beartype.roar.BeartypeCallHintPepParamException):
+        with self.assertRaises(beartype.roar.BeartypeCallHintParamViolation):
             with self.assertRaises(TypeError):
                 networkplot(adjacency=X, x=x, y=y, context=context)
 
@@ -117,7 +117,7 @@ class TestPlot(unittest.TestCase):
                 gridplot([X], grid_labels, font_scale=font_scale)
             with self.assertRaises(TypeError):
                 pairplot(X, font_scale=font_scale)
-            with self.assertRaises(beartype.roar.BeartypeCallHintPepParamException):
+            with self.assertRaises(beartype.roar.BeartypeCallHintParamViolation):
                 with self.assertRaises(TypeError):
                     networkplot(adjacency=X, x=x, y=y, font_scale=font_scale)
 
@@ -283,7 +283,7 @@ class TestPlot(unittest.TestCase):
         X = er_np(15, 0.5)
         x = np.random.rand(15, 1)
         y = np.random.rand(15, 1)
-        with self.assertRaises(beartype.roar.BeartypeCallHintPepParamException):
+        with self.assertRaises(beartype.roar.BeartypeCallHintParamViolation):
             with self.assertRaises(TypeError):
                 networkplot(adjacency="test", x=x, y=y)
 


### PR DESCRIPTION
~~Hyppo 0.2.2 (and possibly earlier) use a private scipy function that has been moved in 1.8.0+. Until hyppo fixes this we need to restrict scipy to an earlier version.~~

~~This should be removed once hyppo releases a fix.~~

This branch and PR are just morphing into a general purpose cleanup prior to releasing 1.0.0 (for real this time) and fixing our dependencies.
