### PR TITLE
Error message in Leiden when given a multigraph was incorrect

### DIFF
--- a/graspologic/partition/leiden.py
+++ b/graspologic/partition/leiden.py
@@ -50,7 +50,7 @@ def _nx_to_edge_list(
     check_argument(
         isinstance(graph, nx.Graph)
         and not (graph.is_directed() or graph.is_multigraph()),
-        "Only undirected networkx graphs are supported",
+        "Only undirected non-multi-graph networkx graphs are supported",
     )
     native_safe: List[Tuple[str, str, float]] = []
     edge_iter = (


### PR DESCRIPTION
The exception we raise when given a networkx graph if it's directed or a multigraph implies the only error condition is that it's a directed graph, when that isn't the case.