### PR TITLE
Added tool for building release-notes before dev to main merge. Closes #842

### DIFF
--- a/.github/workflows/automate-release-notes.yml
+++ b/.github/workflows/automate-release-notes.yml
@@ -1,4 +1,4 @@
-name: graspologic Publish
+name: graspologic Build Release Notes
 on:
   push:
     paths:

--- a/.github/workflows/automate-release-notes.yml
+++ b/.github/workflows/automate-release-notes.yml
@@ -1,0 +1,37 @@
+name: graspologic Publish
+on:
+  push:
+    paths:
+      - 'setup.cfg'
+    branches:
+      - 'main'
+      - 'dev'
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.ref=='refs/heads/main' || github.ref=='refs/heads/dev'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel twine
+          pip install -r requirements.txt
+      - name: Create version environment variable
+        run: |
+          echo "GRASPOLOGIC_VERSION=`python setup.py --version`" >> $GITHUB_ENV
+          echo "GRASPOLOGIC_TAG=v`python setup.py --version`" >> $GITHUB_ENV
+      - name: Create release.rst file
+        run: |
+          python buildReleaseNotes.py
+      - name: Commit and Push
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          git commit -m "Release Notes PR"
+          git push

--- a/buildReleaseNotes.py
+++ b/buildReleaseNotes.py
@@ -1,0 +1,17 @@
+import subprocess
+import json
+
+subprocess.call(['sh', './getActionRuns.sh'])
+
+# get PR titles
+PR_title = []
+with open('actionRuns.json', 'r') as f:
+    data = json.load(f)["workflow_runs"]
+    for workflow_run in data:
+        if workflow_run is not None and workflow_run["conclusion"] == "success":
+            PR_title.append(workflow_run["head_commit"]["message"])
+
+# create release.rst
+with open('release.rst', 'a+') as f:
+    for title in PR_title:
+        f.write(title + "\n")

--- a/getActionRuns.sh
+++ b/getActionRuns.sh
@@ -1,0 +1,3 @@
+curl \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/Microsoft/graspologic/actions/workflows/publish.yml/runs" > "actionRuns.json"


### PR DESCRIPTION
Creates list of PR titles from previous release until now aggregated in chronological order and added to the release RST file.

Prior to merge to main, it creates a list of PRs, titles only, that have been merged into dev from previous_release until now, and opens a new PR (called Release Notes PR)

Since it's a PR, the maintainer merging it can look at it, tweak some things if they need to, then merge it into dev right before they merge dev into main and BAM! Release notes will be published.

**Maintainer must manually launch a "create release notes" github action via a manual trigger (change setup.cfg file)**