### PR TITLE
Removed default axis labels in networkplot

### DIFF
--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -1398,6 +1398,8 @@ def networkplot(
         )
         ax.add_collection(lc)
         ax.set(xticks=[], yticks=[])
+        ax.set_xlabel("")
+        ax.set_ylabel("")
 
     return ax
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

This PR modifies the networkplot function such that the graph no longer renders the default x and y axis labels, which in the context of network plots, is meaningless.

#### Any other comments?
