### PR TITLE
Fix to repeated compilation of numba

### DIFF
--- a/graspologic/models/edge_swaps.py
+++ b/graspologic/models/edge_swaps.py
@@ -73,7 +73,7 @@ class EdgeSwapper:
         else:
             # for numpy input, use numba for JIT compilation
             # NOTE: not convinced numba is helping much here, look into optimizing
-            self._edge_swap_function = nb.jit(_edge_swap)
+            self._edge_swap_function = _edge_swap_numba
 
         self.adjacency = adjacency
 
@@ -211,3 +211,5 @@ def _edge_swap(
     edge_list[orig_inds[0]] = [u, x]
     edge_list[orig_inds[1]] = [v, y]
     return adjacency, edge_list
+
+_edge_swap_numba = nb.jit(_edge_swap)


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

Fixes #946

Utilizes the addition of a global function at the top of the file that calls the nb.jit function a single time instead of in the constructor. This speeds up the compilation and running speed of the code.