### PR TITLE
Fixed repeated numba compilation in EdgeSwapper (#964)

### DIFF
--- a/graspologic/models/edge_swaps.py
+++ b/graspologic/models/edge_swaps.py
@@ -73,7 +73,7 @@ class EdgeSwapper:
         else:
             # for numpy input, use numba for JIT compilation
             # NOTE: not convinced numba is helping much here, look into optimizing
-            self._edge_swap_function = nb.jit(_edge_swap)
+            self._edge_swap_function = _edge_swap_numba
 
         self.adjacency = adjacency
 
@@ -211,3 +211,5 @@ def _edge_swap(
     edge_list[orig_inds[0]] = [u, x]
     edge_list[orig_inds[1]] = [v, y]
     return adjacency, edge_list
+
+_edge_swap_numba = nb.jit(_edge_swap)

--- a/graspologic/models/edge_swaps.py
+++ b/graspologic/models/edge_swaps.py
@@ -212,4 +212,5 @@ def _edge_swap(
     edge_list[orig_inds[1]] = [v, y]
     return adjacency, edge_list
 
+
 _edge_swap_numba = nb.jit(_edge_swap)


### PR DESCRIPTION

- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

Fixes #964
this code fixes the issue of repeated compilations of numba in the if/else statement of edge_swaps.py and, instead, sets the jit to a variable at the bottom of the file in order for the jit to compile only once. this makes the code run faster 
