### PR TITLE
Added elbow marker to screeplot in plot module

### DIFF
--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -23,6 +23,7 @@ from sklearn.utils import check_array, check_consistent_length, check_X_y
 from graspologic.types import Dict, List, Tuple
 
 from ..embed import select_svd
+from ..pipeline.embed._elbow import _index_of_elbow
 from ..preconditions import (
     check_argument,
     check_argument_types,
@@ -30,7 +31,6 @@ from ..preconditions import (
 )
 from ..types import GraphRepresentation
 from ..utils import import_graph, pass_to_ranks
-from ..pipeline.embed._elbow import _index_of_elbow
 
 # Type aliases
 FigSizeType = Tuple[int, int]

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -1446,6 +1446,7 @@ def screeplot(
     -------
     ax : matplotlib axis object
         Output plot
+
     References
     ----------
     .. [1] Zhu, M. and Ghodsi, A. (2006).

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -1414,7 +1414,7 @@ def screeplot(
     figsize: Tuple[int, int] = (10, 5),
     cumulative: bool = True,
     show_first: Optional[int] = None,
-    show_elbow: Optional[bool] = False,
+    show_elbow: Optional[Union[bool, int]] = False,
 ) -> matplotlib.pyplot.Axes:
     r"""
     Plots the distribution of singular values for a matrix, either showing the

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -30,6 +30,7 @@ from ..preconditions import (
 )
 from ..types import GraphRepresentation
 from ..utils import import_graph, pass_to_ranks
+from ..pipeline.embed._elbow import _index_of_elbow
 
 # Type aliases
 FigSizeType = Tuple[int, int]
@@ -1413,6 +1414,7 @@ def screeplot(
     figsize: Tuple[int, int] = (10, 5),
     cumulative: bool = True,
     show_first: Optional[int] = None,
+    show_elbow: Optional[bool] = False,
 ) -> matplotlib.pyplot.Axes:
     r"""
     Plots the distribution of singular values for a matrix, either showing the
@@ -1435,11 +1437,21 @@ def screeplot(
         Whether or not to plot a cumulative cdf of singular values
     show_first : int or None, default: None
         Whether to restrict the plot to the first ``show_first`` components
+    show_elbow : bool, or int, default: False
+        Whether to show an elbow (an optimal embedding dimension) estimated
+        via [1]. An integer is interpreted as a number of likelihood
+        elbows to return. Must be ``> 1``.
 
     Returns
     -------
     ax : matplotlib axis object
         Output plot
+    References
+    ----------
+    .. [1] Zhu, M. and Ghodsi, A. (2006).
+        Automatic dimensionality selection from the scree plot via the use of
+        profile likelihood. Computational Statistics & Data Analysis, 51(2),
+        pp.918-930.
     """
     _check_common_inputs(
         figsize=figsize, title=title, context=context, font_scale=font_scale
@@ -1464,6 +1476,13 @@ def screeplot(
     ylabel = "Variance explained"
     with sns.plotting_context(context=context, font_scale=font_scale):
         plt.plot(y)
+        if show_elbow:
+            n_elbows = 2
+            if isinstance(show_elbow, int):
+                n_elbows = show_elbow
+            elb_index = _index_of_elbow(D, n_elbows)
+            if elb_index < len(y):
+                plt.plot(elb_index, y[elb_index], "rx", markersize=20)
         plt.title(title)
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] ~Does this PR add any new dependencies?~
- [x] Does this PR modify any existing APIs?
   - [x] Is the change to the API backwards compatible?
- [ ] ~Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?~

#### What does this implement/fix? Briefly explain your changes.

I thought it would be nice to have an option that plots a marker with an estimated elbow at the screeplot.

![Screenshot 2022-07-29 at 14 39 20](https://user-images.githubusercontent.com/4547289/181905911-97ebe5b1-bc79-483b-8c91-06288633ee4c.png)

This simple PR adds it.