### PR TITLE
[BUG FIXED] Removed outdated Zenodo DOI from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![PyPI version](https://img.shields.io/pypi/v/graspologic.svg)](https://pypi.org/project/graspologic/)
 [![Downloads shield](https://pepy.tech/badge/graspologic)](https://pepy.tech/project/graspologic)
 ![graspologic CI](https://github.com/microsoft/graspologic/workflows/graspologic%20CI/badge.svg)
-[![DOI](https://zenodo.org/badge/147768493.svg)](https://zenodo.org/badge/latestdoi/147768493)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## `graspologic` is a package for graph statistical algorithms.


### PR DESCRIPTION
Removed outdated Zenodo DOI from README.md

**BEFORE**
![Screenshot from 2022-10-10 02-27-02](https://user-images.githubusercontent.com/96724863/194779146-9ef70ce6-cd3b-4566-b2b9-3e905fde18f3.png)

**AFTER**
![Screenshot from 2022-10-10 02-26-46](https://user-images.githubusercontent.com/96724863/194779159-4910b74d-b2ff-49ed-8e78-af183bab9563.png)
