### PR TITLE
Fixed bug where seaborn was incompatible with matplotlib 3.6.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     graspologic-native>=1.1.1
     hyppo>=0.3.2 # bug with lower versions and scipy>=1.8
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
-    matplotlib>=3.0.0,!=3.3*,!=3.6.1
+    matplotlib>=3.0.0,!=3.3.*,!=3.6.1
     networkx>=2.1
     numpy>=1.8.1
     POT>=0.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     graspologic-native>=1.1.1
     hyppo>=0.3.2 # bug with lower versions and scipy>=1.8
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
-    matplotlib>=3.0.0,!=3.3.*
+    matplotlib>=3.0.0,!=3.3*,!=3.6.1
     networkx>=2.1
     numpy>=1.8.1
     POT>=0.7.0


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #995 

#### What does this implement/fix? Briefly explain your changes.
This should allow Seaborn and Matlab plot to co-exist in graspologic 
#### Any other comments?
