### PR TITLE
Fixed bug in check_dirloop, check_r and check_rel_sbm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ branch using a virtual environment. Steps:
    right of the page. This creates a copy of the code under your GitHub user account. For more details on how to
    fork a repository see [this guide](https://help.github.com/articles/fork-a-repo/).
 
-2. Clone your fork of the `graspologic` repo from your GitHub account to your local disk:
+2. Clone your fork of the `graspologic` repo from your GitHub account to your local disk. Do this by typing the following into command prompt or the equivelant on your operating system:
 
    ```bash
    git clone git@github.com:YourGithubAccount/graspologic.git
@@ -87,8 +87,7 @@ branch using a virtual environment. Steps:
    Always use a `feature` branch. Pull requests directly to either `dev` or `main` will be rejected
    until you create a feature branch based on `dev`.
 
-4. From the project root, create a [virtual environment](https://docs.python.org/3/library/venv.html) and install all development dependencies. Examples using various terminals are provided below. These examples use Python 3.8 but you may use any Python version supported by graspologic. These commands should install `graspologic` in editable mode, as well as
-all of its dependencies and several tools you need for developing `graspologic`.
+4. From the project root, create a [virtual environment](https://docs.python.org/3/library/venv.html) and install all development dependencies. Examples using various terminals are provided below. These examples use Python 3.8 but you may use any Python version supported by graspologic. If using Python 3.8 does not work feel free to type the same command simply using "Python" instead of "Python 3.8".These commands should install `graspologic` in editable mode, as well as all of its dependencies and several tools you need for developing `graspologic`. These commands assume that your operating system has already activated virtual environments which will allow virtual environments to be created. 
 
    **Bash**
     ```bash

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![PyPI version](https://img.shields.io/pypi/v/graspologic.svg)](https://pypi.org/project/graspologic/)
 [![Downloads shield](https://pepy.tech/badge/graspologic)](https://pepy.tech/project/graspologic)
 ![graspologic CI](https://github.com/microsoft/graspologic/workflows/graspologic%20CI/badge.svg)
-[![DOI](https://zenodo.org/badge/147768493.svg)](https://zenodo.org/badge/latestdoi/147768493)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## `graspologic` is a package for graph statistical algorithms.

--- a/docs/reference/release.rst
+++ b/docs/reference/release.rst
@@ -3,6 +3,15 @@
 Release Log
 ===========
 
+graspologic 2.0.1
+-----------------
+- Fixed bug with a matplotlib version incompatibility
+  `#996 <https://github.com/microsoft/graspologic/pull/996>`
+- Fixed graph matching with similarity matrix of unequal dimensions
+  `#1002 <https://github.com/microsoft/graspologic/pull/1002>`
+- Fixed bug with missing typing-extensions dependency
+  `#999 <https://github.com/microsoft/graspologic/pull/999>`
+
 graspologic 2.0.0
 -----------------
 - Refactored graph matching code and added many new features

--- a/docs/tutorials/embedding/CovariateAssistedEmbed.ipynb
+++ b/docs/tutorials/embedding/CovariateAssistedEmbed.ipynb
@@ -139,7 +139,7 @@
     "def plot_latents(latent_positions, *, title, labels, ax=None):\n",
     "    if ax is None:\n",
     "        ax = plt.gca()\n",
-    "    plot = sns.scatterplot(latent_positions[:, 0], latent_positions[:, 1], hue=labels, \n",
+    "    plot = sns.scatterplot(x=latent_positions[:, 0], y=latent_positions[:, 1], hue=labels, \n",
     "                           linewidth=0, s=10, ax=ax, palette=\"Set1\")\n",
     "    plot.set_title(title, wrap=True);\n",
     "    ax.axes.xaxis.set_visible(False)\n",

--- a/graspologic/match/solver.py
+++ b/graspologic/match/solver.py
@@ -169,6 +169,9 @@ class _GraphMatchSolver:
         _compare_dimensions(B, AB, "row", "column", "B", "AB")
         _compare_dimensions(A, BA, "row", "column", "A", "BA")
         _compare_dimensions(B, BA, "row", "row", "B", "BA")
+        if S is not None:
+            _compare_dimensions(A, [S], "row", "row", "A", "S")
+            _compare_dimensions(B, [S], "column", "column", "B", "S")
 
         # padding for unequally sized inputs
         if self.n_A != self.n_B:
@@ -189,9 +192,11 @@ class _GraphMatchSolver:
         # check for similarity term
         if S is None:
             S = csr_array((self.n, self.n))
+        elif self.padded:
+            S = _adj_pad(S, n_padded=self.n, method="naive")
 
         _compare_dimensions(A, [S], "row", "row", "A", "S")
-        _compare_dimensions(B, [S], "row", "column", "B", "S")
+        _compare_dimensions(B, [S], "column", "column", "B", "S")
 
         self.A = A
         self.B = B
@@ -643,9 +648,7 @@ def _multilayer_adj_pad(
         return new_matrices
 
 
-def _adj_pad(
-    matrix: AdjacencyMatrix, n_padded: Int, method: PaddingType
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+def _adj_pad(matrix: AdjacencyMatrix, n_padded: Int, method: PaddingType) -> np.ndarray:
     if isinstance(matrix, (csr_matrix, csr_array)) and (method == "adopted"):
         msg = (
             "Using adopted padding method with a sparse adjacency representation; this "

--- a/graspologic/simulations/simulations_corr.py
+++ b/graspologic/simulations/simulations_corr.py
@@ -10,14 +10,14 @@ from graspologic.types import List, Tuple
 
 
 def check_dirloop(directed: bool, loops: bool) -> None:
-    if not isinstance(directed, bool):
+    if type(directed) is not bool:
         raise TypeError("directed is not of type bool.")
-    if not isinstance(loops, bool):
+    if type(loops) is not bool:
         raise TypeError("loops is not of type bool.")
 
 
 def check_r(r: float) -> None:
-    if not np.issubdtype(type(r), np.floating):
+    if type(r) is not float:
         raise TypeError("r is not of type float.")
     elif r < -1 or r > 1:
         msg = "r must between -1 and 1."
@@ -35,15 +35,13 @@ def check_rel_er(p: float, r: float) -> None:
 
 
 def check_rel_sbm(p: np.ndarray, r: float) -> None:
-    for i in range(np.array(p).shape[0]):
-        for j in range(np.array(p).shape[1]):
-            if p[i][j] + r * (1 - p[i][j]) < 0:
-                msg = "p + r * (1 - p) should be bigger than 0"
-                raise ValueError(msg)
-
-            elif p[i][j] * (1 - r) < 0:
-                msg = "p * (1 - r) should be bigger than 0"
-                raise ValueError(msg)
+    for i in np.array(p).flat:
+        if i + r * (1 - i) < 0:
+            msg = "p + r * (1 - p) should be bigger than 0"
+            raise ValueError(msg)
+        elif i * (1 - r) < 0:
+            msg = "p * (1 - r) should be bigger than 0"
+            raise ValueError(msg)
 
 
 def sample_edges_corr(

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     graspologic-native>=1.1.1
     hyppo>=0.3.2 # bug with lower versions and scipy>=1.8
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
-    matplotlib>=3.0.0,!=3.3*,!=3.6.1
+    matplotlib>=3.0.0,!=3.3.*,!=3.6.1
     networkx>=2.1
     numpy>=1.8.1
     POT>=0.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     graspologic-native>=1.1.1
     hyppo>=0.3.2 # bug with lower versions and scipy>=1.8
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
-    matplotlib>=3.0.0,!=3.3.*
+    matplotlib>=3.0.0,!=3.3*,!=3.6.1
     networkx>=2.1
     numpy>=1.8.1
     POT>=0.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ exclude =
 dev =
      black
      ipykernel>=5.1.0
-     ipython>=7.4.0
+     ipython>=7.4.0,!=8.7.0 # https://github.com/spatialaudio/nbsphinx/issues/687#issuecomment-1339271312
      isort>=5.9.3
      mypy>=0.910
      nbsphinx>=0.8.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = graspologic
-version = 2.0.0
+version = 2.0.1
 
 description = A set of python modules for graph statistics
 long_description = file: README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     seaborn>= 0.11.0
     scikit-learn>=0.22.0
     scipy>=1.4.0
+    typing-extensions>=4.4.0
     umap-learn>=0.4.6
 
 [options.packages.find]

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -287,3 +287,18 @@ class TestGraphMatch(unittest.TestCase):
             ).mean() / n_sims
 
         self.assertTrue(mean_match_ratio >= 0.999)
+
+    def test_similatiry_padded(self):
+        np.random.seed(88)
+        A = np.random.rand(10, 10)
+        B = np.random.rand(11, 11)
+        S = np.eye(10, 11) * 10
+
+        _, perm_B, _, misc = graph_match(A, B, S=S)
+        self.assertEqual((perm_B == np.arange(10)).mean(), 1.0)
+
+        # want to make sure obj func value is the same as if we hadn't padded S,
+        # should be since we use naive padding only
+        score = misc[0]["score"]
+        out_score = np.sum(A * B[perm_B][:, perm_B]) + np.trace(S[:, perm_B])
+        self.assertEqual(score, out_score)


### PR DESCRIPTION
check_dirloop: You could try replacing the isinstance checks with simple type checks, since bool is a subclass of int and isinstance will also return True if the argument is an int.

check_r: You could try replacing the np.issubdtype check with a simple type check, since float is a subclass of int and np.issubdtype will also return True if the argument is an int.

check_rel_sbm: You could try replacing the nested for loops with a single loop over the flattened array, using the ndarray.flat attribute