### PR TITLE
hard capped networkx version to avoid incompatability

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     hyppo>=0.3.2 # bug with lower versions and scipy>=1.8
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,!=3.3.*,!=3.6.1
-    networkx>=2.1,<=3.0
+    networkx>=2.1,<3.0
     numpy>=1.8.1
     POT>=0.7.0
     seaborn>= 0.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     hyppo>=0.3.2 # bug with lower versions and scipy>=1.8
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,!=3.3.*,!=3.6.1
-    networkx>=2.1,!=3.0
+    networkx>=2.1,<=3.0
     numpy>=1.8.1
     POT>=0.7.0
     seaborn>= 0.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     hyppo>=0.3.2 # bug with lower versions and scipy>=1.8
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,!=3.3.*,!=3.6.1
-    networkx>=2.1
+    networkx>=2.1,!=3.0
     numpy>=1.8.1
     POT>=0.7.0
     seaborn>= 0.11.0


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes?
seems so
- [x] Does this PR add any new dependencies?
nope
- [x] Does this PR modify any existing APIs?
nope
   - [x] Is the change to the API backwards compatible?
 irrelevant
- [x] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?
unapplicable?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #1015.

#### What does this implement/fix? Briefly explain your changes.
Quick-patches the incompatibility by avoiding the netoworkx v.3.0. 

#### Any other comments?
Probably need a better long term fix. Unsure if removing the orderedgraph arguments is sufficient and/or backward compatible.