### PR TITLE
Fixed NetworkX 3 compatibility and switched to sparse arrays (not matrices)

### DIFF
--- a/docs/tutorials/models/edge_swaps.ipynb
+++ b/docs/tutorials/models/edge_swaps.ipynb
@@ -18,14 +18,15 @@
     "from graspologic.plot import heatmap\n",
     "from graspologic.utils import binarize, symmetrize\n",
     "import networkx as nx\n",
-    "from scipy.sparse import csr_matrix"
+    "from scipy.sparse import csr_array"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`EdgeSwapper` is a class that performs degree preserving edge swaps on networks. The distributions of graphs with a fixed degree sequence are known as configuration models, and these have extensive application for analyzing network datasets. The current implementation works on simple graphs (unewighted, no loops) that are of type `np.ndarray` or `csr_matrix`."
+    "`EdgeSwapper` is a class that performs degree preserving edge swaps on networks. The distributions of graphs with a fixed degree sequence are known as configuration models, and these have extensive application for analyzing network datasets. The current implementation works on simple graphs (unewighted, no loops) that are of type `np.ndarray` or `csr_array`."
    ]
   },
   {
@@ -115,10 +116,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`EdgeSwapper` also works with `csr_matrix` adjacency representations. "
+    "`EdgeSwapper` also works with `csr_array` adjacency representations. "
    ]
   },
   {
@@ -127,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "swapper = EdgeSwapper(csr_matrix(adj), seed=8888)\n",
+    "swapper = EdgeSwapper(csr_array(adj), seed=8888)\n",
     "swapped_adj, _ = swapper.swap_edges(n_swaps=1000)\n",
     "g = nx.from_numpy_array(adj)\n",
     "swapped_g = nx.from_numpy_array(swapped_adj)\n",

--- a/graspologic/embed/ase.py
+++ b/graspologic/embed/ase.py
@@ -40,7 +40,7 @@ class AdjacencySpectralEmbed(BaseSpectralEmbed):
             :func:`sklearn.utils.extmath.randomized_svd`
         - 'full'
             Computes full svd using :func:`scipy.linalg.svd`
-            Does not support ``graph`` input of type scipy.sparse.csr_matrix
+            Does not support ``graph`` input of type scipy.sparse.csr_array
         - 'truncated'
             Computes truncated svd using :func:`scipy.sparse.linalg.svds`
 
@@ -149,7 +149,7 @@ class AdjacencySpectralEmbed(BaseSpectralEmbed):
 
         Parameters
         ----------
-        graph : array-like, scipy.sparse.csr_matrix, or networkx.Graph
+        graph : array-like, scipy.sparse.csr_array, or networkx.Graph
             Input graph to embed.
 
         y: Ignored

--- a/graspologic/embed/lse.py
+++ b/graspologic/embed/lse.py
@@ -159,7 +159,7 @@ class LaplacianSpectralEmbed(BaseSpectralEmbed):
 
         Parameters
         ----------
-        graph : array-like, scipy.sparse.csr_matrix, or networkx.Graph
+        graph : array-like, scipy.sparse.csr_array, or networkx.Graph
             Input graph to embed. see graspologic.utils.import_graph
 
         Returns

--- a/graspologic/embed/mase.py
+++ b/graspologic/embed/mase.py
@@ -212,9 +212,9 @@ class MultipleASE(BaseEmbedMulti):
 
         Parameters
         ----------
-        graphs : list of nx.Graph, ndarray or scipy.sparse.csr_matrix
+        graphs : list of nx.Graph, ndarray or scipy.sparse.csr_array
             If list of nx.Graph, each Graph must contain same number of nodes.
-            If list of ndarray or csr_matrix, each array must have shape (n_vertices, n_vertices).
+            If list of ndarray or csr_array, each array must have shape (n_vertices, n_vertices).
             If ndarray, then array must have shape (n_graphs, n_vertices, n_vertices).
 
         Returns
@@ -252,9 +252,9 @@ class MultipleASE(BaseEmbedMulti):
 
         Parameters
         ----------
-        graphs : list of nx.Graph, ndarray or scipy.sparse.csr_matrix
+        graphs : list of nx.Graph, ndarray or scipy.sparse.csr_array
             If list of nx.Graph, each Graph must contain same number of nodes.
-            If list of ndarray or csr_matrix, each array must have shape (n_vertices, n_vertices).
+            If list of ndarray or csr_array, each array must have shape (n_vertices, n_vertices).
             If ndarray, then array must have shape (n_graphs, n_vertices, n_vertices).
 
         Returns

--- a/graspologic/embed/omni.py
+++ b/graspologic/embed/omni.py
@@ -52,7 +52,7 @@ def _get_omnibus_matrix_sparse(matrices: List[csr_array]) -> csr_array:
         # row
         rows.append(hstack(current_row))
 
-    return vstack(rows, format="csr")
+    return csr_array(vstack(rows, format="csr"))
 
 
 def _get_laplacian_matrices(
@@ -97,7 +97,7 @@ def _get_omni_matrix(
     out : 2d-array
         Array of shape (n_vertices * n_graphs, n_vertices * n_graphs)
     """
-    if isspmatrix_csr(graphs[0]):
+    if isinstance(graphs[0], csr_array):
         return _get_omnibus_matrix_sparse(graphs)  # type: ignore
 
     shape = graphs[0].shape

--- a/graspologic/embed/omni.py
+++ b/graspologic/embed/omni.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 
 import numpy as np
 from beartype import beartype
-from scipy.sparse import csr_matrix, hstack, isspmatrix_csr, vstack
+from scipy.sparse import csr_array, hstack, isspmatrix_csr, vstack
 
 from graspologic.types import List
 
@@ -17,7 +17,7 @@ from .svd import SvdAlgorithmType
 
 
 @beartype
-def _get_omnibus_matrix_sparse(matrices: List[csr_matrix]) -> csr_matrix:
+def _get_omnibus_matrix_sparse(matrices: List[csr_array]) -> csr_array:
     """
     Generate the omnibus matrix from a list of sparse adjacency matrices as described by 'A central limit theorem
     for an omnibus embedding of random dot product graphs.'
@@ -244,7 +244,7 @@ class OmnibusEmbed(BaseEmbedMulti):
 
         Parameters
         ----------
-        graphs : list of nx.Graph or ndarray, or csr_matrix
+        graphs : list of nx.Graph or ndarray, or csr_array
             If list of nx.Graph, each Graph must contain same number of nodes.
             If list of ndarray, each array must have shape (n_vertices, n_vertices).
             If ndarray, then array must have shape (n_graphs, n_vertices, n_vertices).

--- a/graspologic/embed/svd.py
+++ b/graspologic/embed/svd.py
@@ -58,7 +58,7 @@ def _compute_likelihood(arr: np.ndarray) -> np.ndarray:
 
 
 def select_dimension(
-    X: Union[np.ndarray, sp.csr_matrix],
+    X: Union[np.ndarray, sp.csr_array],
     n_components: Optional[int] = None,
     n_elbows: int = 2,
     threshold: Optional[float] = None,
@@ -108,7 +108,7 @@ def select_dimension(
     """
     # Handle input data
     if not isinstance(X, np.ndarray) and not sp.isspmatrix_csr(X):
-        msg = "X must be a numpy array or scipy.sparse.csr_matrix, not {}.".format(
+        msg = "X must be a numpy array or scipy.sparse.csr_array, not {}.".format(
             type(X)
         )
         raise ValueError(msg)
@@ -185,7 +185,7 @@ def select_dimension(
 
 
 def select_svd(
-    X: Union[np.ndarray, sp.csr_matrix],
+    X: Union[np.ndarray, sp.csr_array],
     n_components: Optional[int] = None,
     n_elbows: Optional[int] = 2,
     algorithm: SvdAlgorithmType = "randomized",
@@ -223,7 +223,7 @@ def select_svd(
             :func:`sklearn.utils.extmath.randomized_svd`
         - 'full'
             Computes full svd using :func:`scipy.linalg.svd`
-            Does not support ``graph`` input of type scipy.sparse.csr_matrix
+            Does not support ``graph`` input of type scipy.sparse.csr_array
         - 'truncated'
             Computes truncated svd using :func:`scipy.sparse.linalg.svds`
         - 'eigsh'
@@ -266,7 +266,7 @@ def select_svd(
         raise ValueError(msg)
 
     if algorithm == "full" and sp.isspmatrix_csr(X):
-        msg = "'full' agorithm does not support scipy.sparse.csr_matrix inputs."
+        msg = "'full' agorithm does not support scipy.sparse.csr_array inputs."
         raise TypeError(msg)
 
     if n_components is None:

--- a/graspologic/match/solver.py
+++ b/graspologic/match/solver.py
@@ -10,7 +10,7 @@ import numpy as np
 from beartype import beartype
 from ot import sinkhorn
 from scipy.optimize import linear_sum_assignment
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from sklearn.utils import check_scalar
 
 from graspologic.types import List, RngType, Tuple
@@ -492,7 +492,7 @@ def _check_input_matrix(
 ) -> MultilayerAdjacency:
     if isinstance(A, np.ndarray) and (np.ndim(A) == 2):
         A = [A]
-    elif isinstance(A, (csr_matrix, csr_array)):
+    elif isinstance(A, (csr_array, csr_array)):
         A = [A]
     elif isinstance(A, list):
         # iterate over to make sure they're all same shape
@@ -507,7 +507,7 @@ def _check_input_matrix(
                 )
         if isinstance(A[0], np.ndarray):
             A = np.array(A, dtype=float)
-        elif isinstance(A[0], csr_matrix):
+        elif isinstance(A[0], csr_array):
             pass
     if (n_layers is not None) and (len(A) != n_layers):
         msg = (
@@ -649,7 +649,7 @@ def _multilayer_adj_pad(
 
 
 def _adj_pad(matrix: AdjacencyMatrix, n_padded: Int, method: PaddingType) -> np.ndarray:
-    if isinstance(matrix, (csr_matrix, csr_array)) and (method == "adopted"):
+    if isinstance(matrix, (csr_array, csr_array)) and (method == "adopted"):
         msg = (
             "Using adopted padding method with a sparse adjacency representation; this "
             "will convert the matrix to a dense representation and likely remove any "
@@ -661,7 +661,7 @@ def _adj_pad(matrix: AdjacencyMatrix, n_padded: Int, method: PaddingType) -> np.
     if method == "adopted":
         matrix = 2 * matrix - np.ones(matrix.shape)
 
-    if (method == "naive") and isinstance(matrix, (csr_matrix, csr_array)):
+    if (method == "naive") and isinstance(matrix, (csr_array, csr_array)):
         matrix_padded = csr_array((n_padded, n_padded))
     else:
         matrix_padded = np.zeros((n_padded, n_padded))

--- a/graspologic/match/types.py
+++ b/graspologic/match/types.py
@@ -6,19 +6,19 @@ from typing import Union
 import numpy as np
 from packaging import version
 from scipy import __version__ as scipy_version
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 
 if version.parse(scipy_version) >= version.parse("1.8.0"):
     from scipy.sparse import csr_array
 else:
-    csr_array = csr_matrix
+    csr_array = csr_array
 
 from typing_extensions import Literal
 
 from graspologic.types import List, Tuple
 
 # redefining since I don't want to add csr_array for ALL code in graspologic yet
-AdjacencyMatrix = Union[np.ndarray, csr_matrix, csr_array]
+AdjacencyMatrix = Union[np.ndarray, csr_array, csr_array]
 
 MultilayerAdjacency = Union[List[AdjacencyMatrix], AdjacencyMatrix, np.ndarray]
 

--- a/graspologic/match/wrappers.py
+++ b/graspologic/match/wrappers.py
@@ -83,25 +83,25 @@ def graph_match(
 
     Parameters
     ----------
-    A : {ndarray, csr_matrix, csr_array} of shape (n, n), or a list thereof
+    A : {ndarray, csr_array, csr_array} of shape (n, n), or a list thereof
         The first (potentially multilayer) adjacency matrix to be matched. Multiplex
         networks (e.g. a network with multiple edge types) can be used by inputting a
         list of the adjacency matrices for each edge type.
 
-    B : {ndarray, csr_matrix, csr_array} of shape (m, m), or a list thereof
+    B : {ndarray, csr_array, csr_array} of shape (m, m), or a list thereof
         The second (potentially multilayer) adjacency matrix to be matched. Must have
         the same number of layers as ``A``, but need not have the same size
         (see ``padding``).
 
-    AB : {ndarray, csr_matrix, csr_array} of shape (n, m), or a list thereof, default=None
+    AB : {ndarray, csr_array, csr_array} of shape (n, m), or a list thereof, default=None
         A (potentially multilayer) matrix representing connections from the objects
         indexed in ``A`` to those in ``B``, used for bisected graph matching (see [2]).
 
-    BA : {ndarray, csr_matrix, csr_array} of shape (m, n), or a list thereof, default=None
+    BA : {ndarray, csr_array, csr_array} of shape (m, n), or a list thereof, default=None
         A (potentially multilayer) matrix representing connections from the objects
         indexed in ``B`` to those in ``A``, used for bisected graph matching (see [2]).
 
-    S : {ndarray, csr_matrix, csr_array} of shape (n, m), default=None
+    S : {ndarray, csr_array, csr_array} of shape (n, m), default=None
         A matrix representing the similarity of objects indexed in ``A`` to each object
         indexed in ``B``. Note that the scale (i.e. the norm) of this matrix will affect
         how strongly the similarity (linear) term is weighted relative to the adjacency

--- a/graspologic/models/edge_swaps.py
+++ b/graspologic/models/edge_swaps.py
@@ -3,7 +3,7 @@ from typing import Optional
 import numba as nb
 import numpy as np
 from beartype import beartype
-from scipy.sparse import csr_matrix, lil_matrix
+from scipy.sparse import csr_array, lil_matrix
 from sklearn.utils import check_scalar
 
 from graspologic.preconditions import check_argument
@@ -21,7 +21,7 @@ class EdgeSwapper:
 
     Attributes
     ----------
-    adjacency : np.ndarray OR csr_matrix, shape (n_verts, n_verts)
+    adjacency : np.ndarray OR csr_array, shape (n_verts, n_verts)
         The initial adjacency matrix to perform edge swaps on. Must be unweighted and undirected.
 
     edge_list : np.ndarray, shape (n_verts, 2)
@@ -65,7 +65,7 @@ class EdgeSwapper:
 
         adjacency = import_graph(adjacency, copy=True)
 
-        if isinstance(adjacency, csr_matrix):
+        if isinstance(adjacency, csr_array):
             # more efficient for manipulations which change sparsity structure
             adjacency = lil_matrix(adjacency)
             self._edge_swap_function = _edge_swap
@@ -128,7 +128,7 @@ class EdgeSwapper:
 
         adjacency = self.adjacency
         if isinstance(adjacency, lil_matrix):
-            adjacency = csr_matrix(adjacency)
+            adjacency = csr_array(adjacency)
         else:
             adjacency = adjacency.copy()
 
@@ -141,11 +141,11 @@ def _edge_swap(
     """
     Performs the edge swap on the adjacency matrix. If adjacency is
     np.ndarray, then nopython=True is used in numba, but if adjacency
-    is csr_matrix, then forceobj=True is used in numba
+    is csr_array, then forceobj=True is used in numba
 
     Parameters
     ----------
-    adjacency : np.ndarray OR csr_matrix, shape (n_verts, n_verts)
+    adjacency : np.ndarray OR csr_array, shape (n_verts, n_verts)
         The initial adjacency matrix in which edge swaps are performed on it
 
     edge_list : np.ndarray, shape (n_verts, 2)
@@ -156,7 +156,7 @@ def _edge_swap(
 
     Returns
     -------
-    adjacency : np.ndarray OR csr_matrix, shape (n_verts, n_verts)
+    adjacency : np.ndarray OR csr_array, shape (n_verts, n_verts)
         The adjancency matrix after an edge swap is performed on the graph
 
     edge_list : np.ndarray (n_verts, 2)

--- a/graspologic/partition/leiden.py
+++ b/graspologic/partition/leiden.py
@@ -81,7 +81,7 @@ def _adjacency_matrix_to_edge_list(
     shape = matrix.shape
     if len(shape) != 2 or shape[0] != shape[1]:
         raise ValueError(
-            "graphs of type np.ndarray or csr.sparse.csr.csr_matrix should be "
+            "graphs of type np.ndarray or csr.sparse.csr.csr_array should be "
             "adjacency matrices with n x n shape"
         )
 
@@ -205,7 +205,7 @@ def leiden(
     graph : Union[List[Tuple[Any, Any, Union[int, float]]], GraphRepresentation]
         A graph representation, whether a weighted edge list referencing an undirected
         graph, an undirected networkx graph, or an undirected adjacency matrix in either
-        numpy.ndarray or scipy.sparse.csr.csr_matrix form. Please see the Notes section
+        numpy.ndarray or scipy.sparse.csr_array form. Please see the Notes section
         regarding node ids used.
     starting_communities : Optional[Dict[Any, int]]
         Default is ``None``. An optional community mapping dictionary that contains a node
@@ -419,7 +419,7 @@ def hierarchical_leiden(
         List[Tuple[Any, Any, Union[int, float]]],
         nx.Graph,
         np.ndarray,
-        scipy.sparse.csr_matrix,
+        scipy.sparse.csr_array,
     ],
     max_cluster_size: int = 1000,
     starting_communities: Optional[Dict[str, int]] = None,
@@ -466,7 +466,7 @@ def hierarchical_leiden(
     graph : Union[List[Tuple[Any, Any, Union[int, float]]], GraphRepresentation]
         A graph representation, whether a weighted edge list referencing an undirected
         graph, an undirected networkx graph, or an undirected adjacency matrix in either
-        numpy.ndarray or scipy.sparse.csr.csr_matrix form. Please see the Notes section
+        numpy.ndarray or scipy.sparse.csr_array form. Please see the Notes section
         regarding node ids used.
     max_cluster_size : int
         Default is ``1000``. Any partition or cluster with

--- a/graspologic/pipeline/embed/_types.py
+++ b/graspologic/pipeline/embed/_types.py
@@ -1,0 +1,11 @@
+from typing import Union
+
+import networkx as nx
+from pkg_resources import parse_version
+
+major = parse_version(nx.__version__).major
+
+if major >= 3:
+    NxGraphType = Union[nx.Graph, nx.DiGraph]
+else:
+    NxGraphType = Union[nx.Graph, nx.DiGraph, nx.OrderedGraph, nx.OrderedDiGraph]

--- a/graspologic/pipeline/embed/_types.py
+++ b/graspologic/pipeline/embed/_types.py
@@ -1,11 +1,5 @@
 from typing import Union
 
 import networkx as nx
-from pkg_resources import parse_version
 
-major = parse_version(nx.__version__).major
-
-if major >= 3:
-    NxGraphType = Union[nx.Graph, nx.DiGraph]
-else:
-    NxGraphType = Union[nx.Graph, nx.DiGraph, nx.OrderedGraph, nx.OrderedDiGraph]
+NxGraphType = Union[nx.Graph, nx.DiGraph]

--- a/graspologic/pipeline/embed/adjacency_spectral_embedding.py
+++ b/graspologic/pipeline/embed/adjacency_spectral_embedding.py
@@ -20,12 +20,13 @@ from graspologic.utils import (
 
 from . import __SVD_SOLVER_TYPES  # from the module init
 from ._elbow import _index_of_elbow
+from ._types import NxGraphType
 from .embeddings import Embeddings
 
 
 @beartype
 def adjacency_spectral_embedding(
-    graph: Union[nx.Graph, nx.DiGraph, nx.OrderedGraph, nx.OrderedDiGraph],
+    graph: NxGraphType,
     dimensions: int = 100,
     elbow_cut: Optional[int] = None,
     svd_solver_algorithm: SvdAlgorithmType = "randomized",

--- a/graspologic/pipeline/embed/adjacency_spectral_embedding.py
+++ b/graspologic/pipeline/embed/adjacency_spectral_embedding.py
@@ -89,7 +89,7 @@ def adjacency_spectral_embedding(
                 :func:`sklearn.utils.extmath.randomized_svd`
             - 'full'
                 Computes full svd using :func:`scipy.linalg.svd`
-                Does not support ``graph`` input of type scipy.sparse.csr_matrix
+                Does not support ``graph`` input of type scipy.sparse.csr_array
             - 'truncated'
                 Computes truncated svd using :func:`scipy.sparse.linalg.svds`
     svd_solver_iterations : int (default=5)
@@ -177,7 +177,7 @@ def adjacency_spectral_embedding(
         )
         used_weight_attribute = None  # this supercedes what the user said, because
         # not all of the weights are real numbers, if they exist at all
-        # this weight=1.0 treatment actually happens in nx.to_scipy_sparse_matrix()
+        # this weight=1.0 treatment actually happens in nx.to_scipy_sparse_array()
 
     node_labels = np.array(list(graph.nodes()))
 

--- a/graspologic/pipeline/embed/laplacian_spectral_embedding.py
+++ b/graspologic/pipeline/embed/laplacian_spectral_embedding.py
@@ -88,7 +88,7 @@ def laplacian_spectral_embedding(
                 :func:`sklearn.utils.extmath.randomized_svd`
             - 'full'
                 Computes full svd using :func:`scipy.linalg.svd`
-                Does not support ``graph`` input of type scipy.sparse.csr_matrix
+                Does not support ``graph`` input of type scipy.sparse.csr_array
             - 'truncated'
                 Computes truncated svd using :func:`scipy.sparse.linalg.svds`
     svd_solver_iterations : int (default=5)
@@ -193,7 +193,7 @@ def laplacian_spectral_embedding(
         )
         used_weight_attribute = None  # this supercedes what the user said, because
         # not all of the weights are real numbers, if they exist at all
-        # this weight=1.0 treatment actually happens in nx.to_scipy_sparse_matrix()
+        # this weight=1.0 treatment actually happens in nx.to_scipy_sparse_array()
 
     node_labels = np.array(list(graph.nodes()))
 

--- a/graspologic/pipeline/embed/laplacian_spectral_embedding.py
+++ b/graspologic/pipeline/embed/laplacian_spectral_embedding.py
@@ -17,6 +17,7 @@ from graspologic.utils import is_fully_connected, pass_to_ranks, remove_loops
 from ...utils import LaplacianFormType
 from . import __SVD_SOLVER_TYPES  # from the module init
 from ._elbow import _index_of_elbow
+from ._types import NxGraphType
 from .embeddings import Embeddings
 
 __FORMS = ["DAD", "I-DAD", "R-DAD"]
@@ -24,7 +25,7 @@ __FORMS = ["DAD", "I-DAD", "R-DAD"]
 
 @beartype
 def laplacian_spectral_embedding(
-    graph: Union[nx.Graph, nx.OrderedGraph, nx.DiGraph, nx.OrderedDiGraph],
+    graph: NxGraphType,
     form: LaplacianFormType = "R-DAD",
     dimensions: int = 100,
     elbow_cut: Optional[int] = None,

--- a/graspologic/pipeline/embed/omnibus_embedding.py
+++ b/graspologic/pipeline/embed/omnibus_embedding.py
@@ -86,7 +86,7 @@ def omnibus_embedding_pairwise(
                   :func:`sklearn.utils.extmath.randomized_svd`
               - 'full'
                   Computes full svd using :func:`scipy.linalg.svd`
-                  Does not support ``graph`` input of type scipy.sparse.csr_matrix
+                  Does not support ``graph`` input of type scipy.sparse.csr_array
               - 'truncated'
                   Computes truncated svd using :func:`scipy.sparse.linalg.svds`
     svd_solver_iterations : int (default=5)
@@ -260,7 +260,7 @@ def _graphs_precondition_checks(
             )
             used_weight_attribute = None  # this supercedes what the user said, because
             # not all of the weights are real numbers, if they exist at all
-            # this weight=1.0 treatment actually happens in nx.to_scipy_sparse_matrix()
+            # this weight=1.0 treatment actually happens in nx.to_scipy_sparse_array()
 
     return used_weight_attribute
 

--- a/graspologic/pipeline/embed/omnibus_embedding.py
+++ b/graspologic/pipeline/embed/omnibus_embedding.py
@@ -21,12 +21,13 @@ from graspologic.utils import (
 
 from . import __SVD_SOLVER_TYPES
 from ._elbow import _index_of_elbow
+from ._types import NxGraphType
 from .embeddings import Embeddings
 
 
 @beartype
 def omnibus_embedding_pairwise(
-    graphs: List[Union[nx.Graph, nx.OrderedGraph, nx.DiGraph, nx.OrderedDiGraph]],
+    graphs: List[NxGraphType],
     dimensions: int = 100,
     elbow_cut: Optional[int] = None,
     svd_solver_algorithm: SvdAlgorithmType = "randomized",
@@ -230,7 +231,7 @@ def omnibus_embedding_pairwise(
 
 
 def _graphs_precondition_checks(
-    graphs: List[Union[nx.Graph, nx.OrderedGraph, nx.DiGraph, nx.OrderedDiGraph]],
+    graphs: List[NxGraphType],
     weight_attribute: str,
 ) -> Optional[str]:
     is_directed = graphs[0].is_directed()
@@ -291,7 +292,7 @@ def _elbow_cut_if_needed(
 
 
 def _augment_graph(
-    graph: Union[nx.Graph, nx.OrderedGraph, nx.DiGraph, nx.OrderedDiGraph],
+    graph: NxGraphType,
     node_ids: Set[Hashable],
     weight_attribute: Optional[str],
     perform_augment_diagonal: bool = True,
@@ -311,7 +312,7 @@ def _augment_graph(
 
 
 def _sync_nodes(
-    graph_to_reduce: Union[nx.Graph, nx.OrderedGraph, nx.DiGraph, nx.OrderedDiGraph],
+    graph_to_reduce: NxGraphType,
     set_of_valid_nodes: Set[Hashable],
 ) -> None:
     to_remove = []

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -16,7 +16,7 @@ from matplotlib.collections import LineCollection
 from matplotlib.colors import Colormap
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from scipy import linalg
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from sklearn.preprocessing import Binarizer
 from sklearn.utils import check_array, check_consistent_length, check_X_y
 
@@ -1165,7 +1165,7 @@ def edgeplot(
 
 @beartype
 def networkplot(
-    adjacency: Union[np.ndarray, csr_matrix],
+    adjacency: Union[np.ndarray, csr_array],
     x: Union[np.ndarray, str],
     y: Union[np.ndarray, str],
     node_data: Optional[pd.DataFrame] = None,
@@ -1195,7 +1195,7 @@ def networkplot(
 
     Parameters
     ----------
-    adjacency: np.ndarray, csr_matrix
+    adjacency: np.ndarray, csr_array
         Adjacency matrix of input network.
     x,y: np.ndarray, str
         Variables that specify the positions on the x and y axes. Either an

--- a/graspologic/plot/plot_matrix.py
+++ b/graspologic/plot/plot_matrix.py
@@ -10,13 +10,13 @@ import pandas as pd
 import seaborn as sns
 from matplotlib.colors import ListedColormap
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 
 
 def _check_data(data, plot_type):
     if plot_type == "scattermap":
-        if not isinstance(data, (np.ndarray, csr_matrix)):
-            raise TypeError("`data` must be a np.ndarray or scipy.sparse.csr_matrix.")
+        if not isinstance(data, (np.ndarray, csr_array)):
+            raise TypeError("`data` must be a np.ndarray or scipy.sparse.csr_array.")
     elif plot_type == "heatmap":
         if not isinstance(data, np.ndarray):
             msg = "`data` must be a np.ndarray. If your data is a sparse matrix, please"
@@ -371,7 +371,7 @@ def scattermap(data, ax=None, legend=False, sizes=(5, 10), **kws):
 
     Parameters
     ----------
-    data : np.narray, scipy.sparse.csr_matrix, ndim=2
+    data : np.narray, scipy.sparse.csr_array, ndim=2
         Matrix to plot
     ax: matplotlib axes object, optional
         Axes in which to draw the plot, by default None
@@ -528,7 +528,7 @@ def matrixplot(  # type: ignore
 
     Parameters
     ----------
-    data : np.ndarray or scipy.sparse.csr_matrix with ndim=2
+    data : np.ndarray or scipy.sparse.csr_array with ndim=2
         Matrix to plot. Sparse matrix input is only accepted if ``plot_type == 'scattermap'``.
     ax : matplotlib axes object (default=None)
         Axes in which to draw the plot. If no axis is passed, one will be created.
@@ -911,7 +911,7 @@ def adjplot(  # type: ignore
 
     Parameters
     ----------
-    data : np.ndarray or scipy.sparse.csr_matrix with ndim=2
+    data : np.ndarray or scipy.sparse.csr_array with ndim=2
         Matrix to plot, must be square.
         Sparse matrix input is only accepted if ``plot_type == 'scattermap'``.
     ax : matplotlib axes object (default=None)

--- a/graspologic/types.py
+++ b/graspologic/types.py
@@ -34,9 +34,9 @@ if sys.version_info >= (3, 9):
 else:
     from typing import Dict, List, Set, Tuple
 
-AdjacencyMatrix = Union[np.ndarray, sp.csr_matrix]
+AdjacencyMatrix = Union[np.ndarray, sp.csr_array]
 
-GraphRepresentation = Union[np.ndarray, sp.csr_matrix, nx.Graph]
+GraphRepresentation = Union[np.ndarray, sp.csr_array, nx.Graph]
 
 RngType = Optional[Union[int, np.integer, np.random.Generator]]
 

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -12,7 +12,7 @@ import pandas as pd
 import scipy.sparse
 from beartype import beartype
 from scipy.optimize import linear_sum_assignment
-from scipy.sparse import csgraph, csr_matrix, diags, isspmatrix_csr
+from scipy.sparse import csgraph, csr_array, diags, isspmatrix_csr
 from scipy.sparse.csgraph import connected_components
 from sklearn.metrics import confusion_matrix
 from sklearn.utils import check_array, check_consistent_length, column_or_1d
@@ -26,20 +26,20 @@ from ..types import GraphRepresentation
 
 @beartype
 def average_matrices(
-    matrices: Union[np.ndarray, Union[List[np.ndarray], List[csr_matrix]]]
-) -> Union[np.ndarray, csr_matrix]:
+    matrices: Union[np.ndarray, Union[List[np.ndarray], List[csr_array]]]
+) -> Union[np.ndarray, csr_array]:
     """
     Helper method to encapsulate calculating the average of matrices represented either as a
-    list of numpy.ndarray or a list of scipy.sparse.csr_matrix.
+    list of numpy.ndarray or a list of scipy.sparse.csr_array.
 
     Parameters
     ----------
-    matrices: Union[np.ndarray, Union[List[np.ndarray], List[csr_matrix]]]
+    matrices: Union[np.ndarray, Union[List[np.ndarray], List[csr_array]]]
         The list of matrices to be averaged
 
     Returns
     -------
-    Union[np.ndarray, csr_matrix]
+    Union[np.ndarray, csr_array]
     """
     if isinstance(matrices[0], np.ndarray):
         return np.mean(matrices, axis=0)  # type: ignore
@@ -51,7 +51,7 @@ def average_matrices(
 
 def import_graph(
     graph: GraphRepresentation, copy: bool = True
-) -> Union[np.ndarray, scipy.sparse.csr_matrix]:
+) -> Union[np.ndarray, scipy.sparse.csr_array]:
     """
     A function for reading a graph and returning a shared data type.
 
@@ -59,7 +59,7 @@ def import_graph(
     ----------
     graph: GraphRepresentation
         Either array-like, shape (n_vertices, n_vertices) numpy array,
-        a scipy.sparse.csr_matrix, or an object of type networkx.Graph.
+        a scipy.sparse.csr_array, or an object of type networkx.Graph.
 
     copy: bool, (default=True)
         Whether to return a copied version of array. If False and input is np.array,
@@ -76,7 +76,7 @@ def import_graph(
     """
     if isinstance(graph, (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)):
         out = nx.to_numpy_array(graph, nodelist=sorted(graph.nodes), dtype=np.float_)
-    elif isinstance(graph, (np.ndarray, np.memmap, csr_matrix)):
+    elif isinstance(graph, (np.ndarray, np.memmap, csr_array)):
         shape = graph.shape
         if len(shape) > 3:
             msg = "Input tensor must have at most 3 dimensions, not {}.".format(
@@ -103,7 +103,7 @@ def import_graph(
             copy=copy,
         )
     else:
-        msg = "Input must be networkx.Graph, np.array, or scipy.sparse.csr_matrix,\
+        msg = "Input must be networkx.Graph, np.array, or scipy.sparse.csr_array,\
         not {}.".format(
             type(graph)
         )
@@ -221,10 +221,10 @@ def is_unweighted(
 
     Parameters
     ----------
-    graph : Union[np.ndarray, scipy.sparse.csr_matrix, nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDigraph]
+    graph : Union[np.ndarray, scipy.sparse.csr_array, nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDigraph]
         The graph to test for weightedness. If a networkx graph, we can just ask it directly by querying the weight
         attribute specified on every edge. It's possible an individual edge can be weighted but the full graph is not.
-        If an adjacency matrix defined by a numpy.ndarray or scipy.sparse.csr_matrix, we check every value; if
+        If an adjacency matrix defined by a numpy.ndarray or scipy.sparse.csr_array, we check every value; if
         they are only 0 and 1, we claim the graph is unweighted.
     weight_attribute : Any
         Default is ``weight``. Only used for networkx, and used on the edge data dictionary as a key to look up the
@@ -238,17 +238,17 @@ def is_unweighted(
     Raises
     ------
     TypeError
-        If the provided graph is not a numpy.ndarray, scipy.sparse.csr_matrix, or nx.Graph
+        If the provided graph is not a numpy.ndarray, scipy.sparse.csr_array, or nx.Graph
     """
     if isinstance(graph, np.ndarray):
         return ((graph == 0) | (graph == 1)).all()
-    elif isinstance(graph, csr_matrix):
+    elif isinstance(graph, csr_array):
         return graph.count_nonzero() == (graph == 1).count_nonzero()
     elif isinstance(graph, nx.Graph):
         return nx.is_weighted(graph, weight=weight_attribute)
     else:
         raise TypeError(
-            "This function only works on numpy.ndarray or scipy.sparse.csr_matrix instances"
+            "This function only works on numpy.ndarray or scipy.sparse.csr_array instances"
         )
 
 
@@ -286,15 +286,15 @@ def is_almost_symmetric(
 
 
 def symmetrize(
-    graph: Union[np.ndarray, csr_matrix], method: Literal["avg", "triu", "tril"] = "avg"
-) -> Union[np.ndarray, csr_matrix]:
+    graph: Union[np.ndarray, csr_array], method: Literal["avg", "triu", "tril"] = "avg"
+) -> Union[np.ndarray, csr_array]:
     """
     A function for forcing symmetry upon a graph.
 
     Parameters
     ----------
     graph: object
-        Either array-like, (n_vertices, n_vertices) numpy matrix or csr_matrix
+        Either array-like, (n_vertices, n_vertices) numpy matrix or csr_array
 
     method: {'avg' (default), 'triu', 'tril',}, optional
         An option indicating which half of the edges to
@@ -343,7 +343,7 @@ def symmetrize(
     return graph
 
 
-def remove_loops(graph: GraphRepresentation) -> Union[np.ndarray, csr_matrix]:
+def remove_loops(graph: GraphRepresentation) -> Union[np.ndarray, csr_array]:
     """
     A function to remove loops from a graph.
 
@@ -387,7 +387,7 @@ def to_laplacian(
     ----------
     graph: object
         Either array-like, (n_vertices, n_vertices) numpy array,
-        scipy.sparse.csr_matrix, or an object of type networkx.Graph.
+        scipy.sparse.csr_array, or an object of type networkx.Graph.
 
     form: {'I-DAD', 'DAD' (default), 'R-DAD'}, string, optional
 
@@ -493,7 +493,7 @@ def is_fully_connected(graph: GraphRepresentation) -> bool:
     Parameters
     ----------
     graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph,
-        scipy.sparse.csr_matrix, np.ndarray
+        scipy.sparse.csr_array, np.ndarray
         Input graph in any of the above specified formats. If np.ndarray,
         interpreted as an :math:`n \times n` adjacency matrix
 
@@ -516,7 +516,7 @@ def is_fully_connected(graph: GraphRepresentation) -> bool:
     False
     """
 
-    if isinstance(graph, (np.ndarray, csr_matrix)):
+    if isinstance(graph, (np.ndarray, csr_array)):
         directed = not is_symmetric(graph)
 
         n_components = connected_components(
@@ -531,12 +531,10 @@ def is_fully_connected(graph: GraphRepresentation) -> bool:
 
 def largest_connected_component(
     graph: Union[
-        nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph, np.ndarray, csr_matrix
+        nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph, np.ndarray, csr_array
     ],
     return_inds: bool = False,
-) -> Union[
-    nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph, np.ndarray, csr_matrix
-]:
+) -> Union[nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph, np.ndarray, csr_array]:
     r"""
     Finds the largest connected component for the input graph.
 
@@ -545,9 +543,9 @@ def largest_connected_component(
 
     Parameters
     ----------
-    graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray, scipy.sparse.csr_matrix
+    graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray, scipy.sparse.csr_array
         Input graph in any of the above specified formats. If np.ndarray or
-        scipy.sparse.csr_matrix interpreted as an :math:`n \times n` adjacency matrix.
+        scipy.sparse.csr_array interpreted as an :math:`n \times n` adjacency matrix.
 
     return_inds: boolean, default: False
         Whether to return a np.ndarray containing the indices/nodes in the original
@@ -555,7 +553,7 @@ def largest_connected_component(
 
     Returns
     -------
-    graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray, scipy.sparse.csr_matrix
+    graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray, scipy.sparse.csr_array
         New graph of the largest connected component, returned in the input format.
 
     inds: (optional)
@@ -564,7 +562,7 @@ def largest_connected_component(
 
     Notes
     -----
-    For networks input in ``scipy.sparse.csr_matrix`` format, explicit zeros are removed
+    For networks input in ``scipy.sparse.csr_array`` format, explicit zeros are removed
     prior to finding the largest connected component, thus they are not treated as
     edges. This differs from the convention in
     :func:`scipy.sparse.csgraph.connected_components`.
@@ -572,12 +570,12 @@ def largest_connected_component(
 
     if isinstance(graph, (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)):
         return _largest_connected_component_networkx(graph, return_inds=return_inds)
-    elif isinstance(graph, (np.ndarray, csr_matrix)):
+    elif isinstance(graph, (np.ndarray, csr_array)):
         return _largest_connected_component_adjacency(graph, return_inds=return_inds)
     else:
         msg = (
             "`graph` must either be a networkx graph or an adjacency matrix in"
-            " numpy ndarray or scipy csr_matrix format."
+            " numpy ndarray or scipy csr_array format."
         )
         raise TypeError(msg)
 
@@ -601,12 +599,12 @@ def _largest_connected_component_networkx(
 
 
 def _largest_connected_component_adjacency(
-    adjacency: Union[np.ndarray, csr_matrix],
+    adjacency: Union[np.ndarray, csr_array],
     return_inds: bool = False,
 ) -> Union[
-    np.ndarray, csr_matrix, Tuple[np.ndarray, np.ndarray], Tuple[csr_matrix, csr_matrix]
+    np.ndarray, csr_array, Tuple[np.ndarray, np.ndarray], Tuple[csr_array, csr_array]
 ]:
-    if isinstance(adjacency, csr_matrix):
+    if isinstance(adjacency, csr_array):
         adjacency.eliminate_zeros()
 
     # If you treat an undirected graph as directed and take the largest weakly connected
@@ -778,7 +776,7 @@ def multigraph_lcc_intersection(
 
 def augment_diagonal(
     graph: GraphRepresentation, weight: float = 1
-) -> Union[np.ndarray, csr_matrix]:
+) -> Union[np.ndarray, csr_array]:
     r"""
     Replaces the diagonal of an adjacency matrix with :math:`\frac{d}{nverts - 1}` where
     :math:`d` is the degree vector for an unweighted graph and the sum of magnitude of
@@ -796,7 +794,7 @@ def augment_diagonal(
 
     Returns
     -------
-    graph : np.array or csr_matrix
+    graph : np.array or csr_array
         Adjacency matrix with average degrees added to the diagonal.
 
     Examples
@@ -827,7 +825,7 @@ def augment_diagonal(
     return graph
 
 
-def binarize(graph: GraphRepresentation) -> Union[np.ndarray, csr_matrix]:
+def binarize(graph: GraphRepresentation) -> Union[np.ndarray, csr_array]:
     """
     Binarize the input adjacency matrix.
 
@@ -926,9 +924,9 @@ def remove_vertices(
     indices: Union[int, np.ndarray, Sequence[int]],
     return_removed: bool = False,
 ) -> Union[
-    Union[np.ndarray, csr_matrix],
-    Tuple[Union[np.ndarray, csr_matrix], np.ndarray],
-    Tuple[Union[np.ndarray, csr_matrix], Tuple[np.ndarray, np.ndarray]],
+    Union[np.ndarray, csr_array],
+    Tuple[Union[np.ndarray, csr_array], np.ndarray],
+    Tuple[Union[np.ndarray, csr_array], Tuple[np.ndarray, np.ndarray]],
 ]:
     """
     Remove a subgraph of adjacency vectors from an adjacency matrix, giving back the

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     hyppo>=0.3.2 # bug with lower versions and scipy>=1.8
     joblib>=0.17.0  # Older versions of joblib cause issue #806.  Transitive dependency of hyppo.
     matplotlib>=3.0.0,!=3.3.*,!=3.6.1
-    networkx>=2.1,<3.0
+    networkx>=2.1
     numpy>=1.8.1
     POT>=0.7.0
     seaborn>= 0.11.0

--- a/tests/embed/test_omni.py
+++ b/tests/embed/test_omni.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from numpy.linalg import norm
 from numpy.testing import assert_allclose
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 
 from graspologic.embed.omni import OmnibusEmbed, _get_omni_matrix
 from graspologic.simulations.simulations import er_nm, er_np
@@ -200,7 +200,7 @@ class TestOmni(unittest.TestCase):
             Abar = (A1 + A2) / 2
 
             omni = OmnibusEmbed(n_components=3, diag_aug=diag_aug)
-            OmniBar = compute_bar(omni.fit_transform([csr_matrix(A1), csr_matrix(A2)]))
+            OmniBar = compute_bar(omni.fit_transform([csr_array(A1), csr_array(A2)]))
 
             omni = OmnibusEmbed(n_components=3, diag_aug=diag_aug)
             ABar = compute_bar(omni.fit_transform([Abar, Abar]))
@@ -262,7 +262,7 @@ class TestOmni(unittest.TestCase):
             Lbar = (L1 + L2) / 2
 
             omni = OmnibusEmbed(n_components=3, diag_aug=diag_aug, lse=True)
-            OmniBar = compute_bar(omni.fit_transform([csr_matrix(L1), csr_matrix(L2)]))
+            OmniBar = compute_bar(omni.fit_transform([csr_array(L1), csr_array(L2)]))
 
             omni = OmnibusEmbed(n_components=3, diag_aug=diag_aug, lse=True)
             LBar = compute_bar(omni.fit_transform([Lbar, Lbar]))

--- a/tests/partition/test_leiden.py
+++ b/tests/partition/test_leiden.py
@@ -308,7 +308,7 @@ class TestLeidenIsolates(unittest.TestCase):
 
         self.assert_isolate_not_in_hierarchical_result(hierarchical_partitions)
 
-    def test_isolate_nodes_in_csr_matrix_are_not_returned(self):
+    def test_isolate_nodes_in_csr_array_are_not_returned(self):
         sparse_adj_matrix = nx.to_scipy_sparse_array(self.graph)
 
         self.assertEqual(
@@ -524,7 +524,7 @@ class TestValidEdgeList(unittest.TestCase):
                 weight_default=1.0,
             )
 
-        sparse = scipy.sparse.csr_matrix([])
+        sparse = scipy.sparse.csr_array([])
         with self.assertRaises(ValueError):
             _adjacency_matrix_to_edge_list(
                 matrix=sparse,
@@ -546,7 +546,7 @@ class TestValidEdgeList(unittest.TestCase):
             )
         with self.assertRaises(ValueError):
             _adjacency_matrix_to_edge_list(
-                matrix=scipy.sparse.csr_matrix(data),
+                matrix=scipy.sparse.csr_array(data),
                 identifier=_IdentityMapper(),
                 check_directed=True,
                 is_weighted=True,

--- a/tests/pipeline/test_graph_builder.py
+++ b/tests/pipeline/test_graph_builder.py
@@ -39,7 +39,7 @@ class TestGraphBuilder(unittest.TestCase):
         self.assertDictEqual(
             expected_old_to_new, old_to_new, "The old to new dictionary should match"
         )
-        nx.testing.assert_graphs_equal(compressed_nx, expected_graph)
+        nx.utils.assert_graphs_equal(compressed_nx, expected_graph)
 
     def test_weighted_graph_builder(self):
         edges = [("nick", "dax", 5.0), ("foo", "bar", 3.2)]
@@ -53,7 +53,7 @@ class TestGraphBuilder(unittest.TestCase):
             builder.add_edge(source, target, weight)
 
         compressed, old_to_new, new_to_old = builder.build()
-        nx.testing.assert_graphs_equal(expected_nx, compressed)
+        nx.utils.assert_graphs_equal(expected_nx, compressed)
         self.assertListEqual(expected_new_to_old, new_to_old)
         self.assertDictEqual(expected_old_to_new, old_to_new)
 
@@ -88,7 +88,7 @@ class TestGraphBuilder(unittest.TestCase):
 
         self.assertListEqual(expected_new_to_old, new_to_old)
         self.assertDictEqual(expected_old_to_new, old_to_new)
-        nx.testing.assert_graphs_equal(expected_nx, compressed)
+        nx.utils.assert_graphs_equal(expected_nx, compressed)
 
     def test_int_graph_builder(self):
         edges = [(5000, 5001, 10.3), (13, 0, 11.1)]
@@ -106,7 +106,7 @@ class TestGraphBuilder(unittest.TestCase):
         compressed, old_to_new, new_to_old = builder.build()
         self.assertListEqual(new_to_old, expected_new_to_old)
         self.assertDictEqual(old_to_new, expected_old_to_new)
-        nx.testing.assert_graphs_equal(expected_nx, compressed)
+        nx.utils.assert_graphs_equal(expected_nx, compressed)
 
     def test_directed_graph_builder(self):
         edges = [("nick", "dax", 14.0), ("dax", "ben", 3.0), ("dax", "nick", 2.2)]
@@ -124,7 +124,7 @@ class TestGraphBuilder(unittest.TestCase):
         compressed, old_to_new, new_to_old = builder.build()
         self.assertListEqual(new_to_old, expected_new_to_old)
         self.assertDictEqual(old_to_new, expected_old_to_new)
-        nx.testing.assert_graphs_equal(expected_nx, compressed)
+        nx.utils.assert_graphs_equal(expected_nx, compressed)
 
     def test_other_edge_attributes(self):
         builder = GraphBuilder()
@@ -143,4 +143,4 @@ class TestGraphBuilder(unittest.TestCase):
         compressed, old_to_new, new_to_old = builder.build()
         self.assertListEqual(new_to_old, expected_new_to_old)
         self.assertDictEqual(old_to_new, expected_old_to_new)
-        nx.testing.assert_graphs_equal(expected_nx, compressed)
+        nx.utils.assert_graphs_equal(expected_nx, compressed)

--- a/tests/pipeline/test_graph_builder.py
+++ b/tests/pipeline/test_graph_builder.py
@@ -39,7 +39,7 @@ class TestGraphBuilder(unittest.TestCase):
         self.assertDictEqual(
             expected_old_to_new, old_to_new, "The old to new dictionary should match"
         )
-        nx.utils.assert_graphs_equal(compressed_nx, expected_graph)
+        nx.utils.graphs_equal(compressed_nx, expected_graph)
 
     def test_weighted_graph_builder(self):
         edges = [("nick", "dax", 5.0), ("foo", "bar", 3.2)]
@@ -53,7 +53,7 @@ class TestGraphBuilder(unittest.TestCase):
             builder.add_edge(source, target, weight)
 
         compressed, old_to_new, new_to_old = builder.build()
-        nx.utils.assert_graphs_equal(expected_nx, compressed)
+        nx.utils.graphs_equal(expected_nx, compressed)
         self.assertListEqual(expected_new_to_old, new_to_old)
         self.assertDictEqual(expected_old_to_new, old_to_new)
 
@@ -88,7 +88,7 @@ class TestGraphBuilder(unittest.TestCase):
 
         self.assertListEqual(expected_new_to_old, new_to_old)
         self.assertDictEqual(expected_old_to_new, old_to_new)
-        nx.utils.assert_graphs_equal(expected_nx, compressed)
+        nx.utils.graphs_equal(expected_nx, compressed)
 
     def test_int_graph_builder(self):
         edges = [(5000, 5001, 10.3), (13, 0, 11.1)]
@@ -106,7 +106,7 @@ class TestGraphBuilder(unittest.TestCase):
         compressed, old_to_new, new_to_old = builder.build()
         self.assertListEqual(new_to_old, expected_new_to_old)
         self.assertDictEqual(old_to_new, expected_old_to_new)
-        nx.utils.assert_graphs_equal(expected_nx, compressed)
+        nx.utils.graphs_equal(expected_nx, compressed)
 
     def test_directed_graph_builder(self):
         edges = [("nick", "dax", 14.0), ("dax", "ben", 3.0), ("dax", "nick", 2.2)]
@@ -124,7 +124,7 @@ class TestGraphBuilder(unittest.TestCase):
         compressed, old_to_new, new_to_old = builder.build()
         self.assertListEqual(new_to_old, expected_new_to_old)
         self.assertDictEqual(old_to_new, expected_old_to_new)
-        nx.utils.assert_graphs_equal(expected_nx, compressed)
+        nx.utils.graphs_equal(expected_nx, compressed)
 
     def test_other_edge_attributes(self):
         builder = GraphBuilder()
@@ -143,4 +143,4 @@ class TestGraphBuilder(unittest.TestCase):
         compressed, old_to_new, new_to_old = builder.build()
         self.assertListEqual(new_to_old, expected_new_to_old)
         self.assertDictEqual(old_to_new, expected_old_to_new)
-        nx.utils.assert_graphs_equal(expected_nx, compressed)
+        nx.utils.graphs_equal(expected_nx, compressed)

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -98,8 +98,8 @@ class TestLatentDistributionTest(unittest.TestCase):
         np.random.seed(123)
         A1 = er_np(5, 0.8)
         A2 = er_np(5, 0.8)
-        A1_nx = nx.from_numpy_matrix(A1)
-        A2_nx = nx.from_numpy_matrix(A2)
+        A1_nx = nx.from_numpy_array(A1)
+        A2_nx = nx.from_numpy_array(A2)
         # check passing nx, when exepect embeddings
         with self.assertRaises(TypeError):
             latent_distribution_test(A1_nx, A1, input_graph=False)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ import unittest
 import networkx as nx
 import numpy as np
 from numpy.testing import assert_allclose
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import adjusted_rand_score
 
@@ -563,7 +563,7 @@ class TestEdgeSwaps(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.A = er_np(20, 0.5)
-        cls.B = csr_matrix(cls.A)
+        cls.B = csr_array(cls.A)
         cls.C = nx.from_numpy_array(cls.A)
         cls.D = nx.from_scipy_sparse_array(cls.B)
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -7,7 +7,7 @@ import beartype.roar
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from sklearn.mixture import GaussianMixture
 
 from graspologic.plot.plot import (
@@ -289,7 +289,7 @@ class TestPlot(unittest.TestCase):
 
             with self.assertRaises(TypeError):
                 networkplot(
-                    adjacency=csr_matrix(X), x="source", y="target", node_data="data"
+                    adjacency=csr_array(X), x="source", y="target", node_data="data"
                 )
 
             with self.assertRaises(TypeError):
@@ -314,7 +314,7 @@ class TestPlot(unittest.TestCase):
                 networkplot(adjacency=X, x=x, y=y, edge_hue=4)
 
             with self.assertRaises(TypeError):
-                networkplot(adjacency=csr_matrix(X), x=x, y=y, edge_alpha="test")
+                networkplot(adjacency=csr_array(X), x=x, y=y, edge_alpha="test")
 
             with self.assertRaises(TypeError):
                 networkplot(adjacency=X, x=x, y=y, edge_linewidth="test")
@@ -340,10 +340,10 @@ class TestPlot(unittest.TestCase):
         sizes = (10, 200)
 
         fig = networkplot(adjacency=X, x=xarray, y=yarray)
-        fig = networkplot(adjacency=csr_matrix(X), x=xarray, y=yarray)
+        fig = networkplot(adjacency=csr_array(X), x=xarray, y=yarray)
         fig = networkplot(adjacency=X, x=xstring, y=ystring, node_data=node_df)
         fig = networkplot(
-            adjacency=csr_matrix(X), x=xstring, y=ystring, node_data=node_df
+            adjacency=csr_array(X), x=xstring, y=ystring, node_data=node_df
         )
         fig = plt.figure()
         ax = fig.add_subplot(211)

--- a/tests/test_plot_matrix.py
+++ b/tests/test_plot_matrix.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 import pandas as pd
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 
 from graspologic.plot.plot_matrix import adjplot, matrixplot
 from graspologic.simulations.simulations import er_np
@@ -80,7 +80,7 @@ class TestPlotMatrix(unittest.TestCase):
 
     def test_adjplot_sparse(self):
         X = er_np(10, 0.5)
-        adjplot(csr_matrix(X), plot_type="scattermap")
+        adjplot(csr_array(X), plot_type="scattermap")
 
     def test_matrix_inputs(self):
         X = er_np(100, 0.5)
@@ -194,4 +194,4 @@ class TestPlotMatrix(unittest.TestCase):
 
     def test_matrixplot_sparse(self):
         X = er_np(10, 0.5)
-        adjplot(csr_matrix(X), plot_type="scattermap")
+        adjplot(csr_array(X), plot_type="scattermap")

--- a/tests/test_spectral_embed.py
+++ b/tests/test_spectral_embed.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 from numpy.random import normal, poisson
 from numpy.testing import assert_equal
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from sklearn.base import clone
 from sklearn.metrics import adjusted_rand_score, pairwise_distances
 from sklearn.mixture import GaussianMixture
@@ -38,7 +38,7 @@ def _test_output_dim(self, method, sparse=False, *args, **kwargs):
     M = 20
     A = er_nm(n, M) + 5
     if sparse:
-        A = csr_matrix(A)
+        A = csr_array(A)
     embed._reduce_dim(A)
     self.assertEqual(embed.latent_left_.shape, (n, 4))
     self.assertTrue(embed.latent_right_ is None)
@@ -55,7 +55,7 @@ def _test_sbm_er_binary(self, method, P, directed=False, sparse=False, *args, **
     )
 
     if sparse:
-        sbm_sample = csr_matrix(sbm_sample)
+        sbm_sample = csr_array(sbm_sample)
 
     embed_sbm = method(n_components=2, concat=directed, svd_seed=8888)
     X_sbm = embed_sbm.fit_transform(sbm_sample)
@@ -233,7 +233,7 @@ class TestAdjacencySpectralEmbedSparse(unittest.TestCase):
         _test_sbm_er_binary(self, AdjacencySpectralEmbed, P, directed=True, sparse=True)
 
     def test_unconnected_warning(self):
-        A = csr_matrix(er_nm(100, 10))
+        A = csr_array(er_nm(100, 10))
         with pytest.warns(UserWarning):
             ase = AdjacencySpectralEmbed()
             ase.fit(A)
@@ -328,13 +328,13 @@ class TestLaplacianSpectralEmbedSparse(unittest.TestCase):
         _test_sbm_er_binary(self, LaplacianSpectralEmbed, P, directed=True, sparse=True)
 
     def test_different_forms(self):
-        f = csr_matrix(np.array([[1, 2], [2, 1]]))
+        f = csr_array(np.array([[1, 2], [2, 1]]))
         lse = LaplacianSpectralEmbed(form="I-DAD")
 
     def test_unconnected_warning(self):
         n = [50, 50]
         p = [[1, 0], [0, 1]]
-        A = csr_matrix(sbm(n, p))
+        A = csr_array(sbm(n, p))
         with pytest.warns(UserWarning):
             lse = LaplacianSpectralEmbed()
             lse.fit(A)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ from math import sqrt
 import networkx as nx
 import numpy as np
 from numpy.testing import assert_equal
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 
 from graspologic.utils import remap_labels
 from graspologic.utils import utils as gus
@@ -26,7 +26,7 @@ class TestAverageMatrices(unittest.TestCase):
             dim2 = random.randint(2, 100)
 
             graphs = [np.random.rand(dim, dim2) for _ in range(number_of_graphs)]
-            graphs_sparse = [csr_matrix(graph) for graph in graphs]
+            graphs_sparse = [csr_array(graph) for graph in graphs]
 
             graphs_averaged = gus.average_matrices(graphs)
             graphs_sparse_averaged = gus.average_matrices(graphs_sparse).todense()
@@ -166,27 +166,27 @@ class TestChecks(unittest.TestCase):
     def test_is_unweighted_for_ones_ndarray(self):
         self.assertTrue(gus.is_unweighted(np.ones((10, 10))))
 
-    def test_is_unweighted_for_zeros_csr_matrix(self):
-        m = csr_matrix((10, 10))
+    def test_is_unweighted_for_zeros_csr_array(self):
+        m = csr_array((10, 10))
         self.assertTrue(gus.is_unweighted(m))
 
-    def test_is_unweighted_for_ones_csr_matrix(self):
-        m = csr_matrix(np.ones((10, 10)))
+    def test_is_unweighted_for_ones_csr_array(self):
+        m = csr_array(np.ones((10, 10)))
         self.assertTrue(gus.is_unweighted(m))
 
-    def test_is_unweighted_for_mixed_zeros_ones_csr_matrix(self):
-        m = csr_matrix((10_000, 10_000))
+    def test_is_unweighted_for_mixed_zeros_ones_csr_array(self):
+        m = csr_array((10_000, 10_000))
         m[0, 1] = 1
         m[1, 1] = 0
         m[9_999, 9_999] = 1.0
         self.assertTrue(gus.is_unweighted(m))
 
-    def test_is_unweighted_for_random_csr_matrix(self):
+    def test_is_unweighted_for_random_csr_array(self):
         dim = 10_000
         num_nonzero = 20
         rows = np.random.randint(0, dim, num_nonzero)
         columns = np.random.randint(0, dim, num_nonzero)
-        m = csr_matrix((dim, dim))
+        m = csr_array((dim, dim))
         m[rows, columns] = np.random.random(num_nonzero)
         self.assertFalse(gus.is_unweighted(m))
 
@@ -312,7 +312,7 @@ class TestLCC(unittest.TestCase):
                 [0, 0, 0, 0, 0, 0, 0],  # not connected
             ]
         )
-        sparse_adjacency = csr_matrix(adjacency)
+        sparse_adjacency = csr_array(adjacency)
 
         lcc_matrix, nodelist = gus.largest_connected_component(
             sparse_adjacency, return_inds=True
@@ -322,7 +322,7 @@ class TestLCC(unittest.TestCase):
 
     def test_lcc_scipy_empty(self):
         adjacency = np.array([[0, 1], [1, 0]])
-        adjacency = csr_matrix(adjacency)
+        adjacency = csr_array(adjacency)
 
         # remove the actual connecting edges. this is now a disconnected graph
         # with two nodes. however, scipy still stores the entry that now has a 0 in it


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [x] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
     - no
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
Fixes #961
Proper fix of #1015 

#### What does this implement/fix? Briefly explain your changes.

#### Any other comments?
- Technically, we're losing support for `nx.OrderedGraph`, but I'm not losing and sleep over that one. I was even considering just switching to NetworkX 3 support only but I don't think it's fully necessary.

