### PR TITLE
Added an `ax` argument for `screeplot()` (FIxes #840)

### DIFF
--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -1425,7 +1425,7 @@ def screeplot(
     cumulative: bool = True,
     show_first: Optional[int] = None,
     show_elbow: Optional[Union[bool, int]] = False,
-) -> None:
+) -> matplotlib.pyplot.Axes:
     r"""
     Plots the distribution of singular values for a matrix, either showing the
     raw distribution or an empirical CDF (depending on ``cumulative``)
@@ -1454,8 +1454,8 @@ def screeplot(
 
     Returns
     -------
-    None
-
+    ax : matplotlib axis object
+        Output plot
 
     References
     ----------
@@ -1496,6 +1496,7 @@ def screeplot(
         plt.title(title)
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)
+    return ax
 
 
 def _sort_inds(

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -1421,7 +1421,7 @@ def screeplot(
     context: str = "talk",
     font_scale: float = 1,
     figsize: Tuple[int, int] = (10, 5),
-    ax: matplotlib.axes.Axes = plt.gca(),
+    ax: Optional[matplotlib.axes.Axes] = None,
     cumulative: bool = True,
     show_first: Optional[int] = None,
     show_elbow: Optional[Union[bool, int]] = False,
@@ -1481,6 +1481,10 @@ def screeplot(
         y = np.cumsum(D[:show_first])
     else:
         y = D[:show_first]
+
+    if ax is None:
+        ax = plt.gca()
+
     _ = plt.figure(figsize=figsize)
     xlabel = "Component"
     ylabel = "Variance explained"

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -1421,10 +1421,11 @@ def screeplot(
     context: str = "talk",
     font_scale: float = 1,
     figsize: Tuple[int, int] = (10, 5),
+    ax: matplotlib.axes.Axes = plt.gca(),
     cumulative: bool = True,
     show_first: Optional[int] = None,
     show_elbow: Optional[Union[bool, int]] = False,
-) -> matplotlib.pyplot.Axes:
+) -> None:
     r"""
     Plots the distribution of singular values for a matrix, either showing the
     raw distribution or an empirical CDF (depending on ``cumulative``)
@@ -1453,8 +1454,8 @@ def screeplot(
 
     Returns
     -------
-    ax : matplotlib axis object
-        Output plot
+    None
+
 
     References
     ----------
@@ -1481,7 +1482,6 @@ def screeplot(
     else:
         y = D[:show_first]
     _ = plt.figure(figsize=figsize)
-    ax = plt.gca()
     xlabel = "Component"
     ylabel = "Variance explained"
     with sns.plotting_context(context=context, font_scale=font_scale):
@@ -1496,7 +1496,6 @@ def screeplot(
         plt.title(title)
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)
-    return ax
 
 
 def _sort_inds(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->
- [ x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [x ] Does this PR modify any existing APIs?
   - [ x] Is the change to the API backwards compatible?
- [x ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
Fixes #840 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
As requested, an argument was added to `screeplot()` for passing in custom axes. If an `ax` argument is not specified, it defaults to `plt.gca()` to prevent issues with code that does not supply an argument.

#### Any other comments?
N/A