### PR TITLE
Limit scipy verion < 1.13.0 due to deprecations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = True
 python_requires = >=3.8, <3.12
 install_requires =
     anytree>=2.8.0
-    beartype>=0.10.0 
+    beartype>=0.10.0
     gensim>=4.0.0,!=4.2.0 # bug with 4.2.0 on some platforms, issue #998
     graspologic-native>=1.1.1
     hyppo>=0.3.2 # bug with lower versions and scipy>=1.8
@@ -39,7 +39,7 @@ install_requires =
     POT>=0.7.0
     seaborn>= 0.11.0
     scikit-learn>=0.22.0
-    scipy>=1.9.0
+    scipy>=1.9.0,<1.13.0
     statsmodels>=0.13.2
     typing-extensions>=4.4.0
     umap-learn>=0.4.6


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/graspologic/blob/dev/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
Fixes #1059 

#### What does this implement/fix? Briefly explain your changes.
Limits scipy version with < 1.13.0

#### Any other comments?
