### PR TITLE
ci: force agg backend on windows and fix whl version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --python ${{ env.PYTHON_VERSION }}
       - name: Run Test Coverage
+        env:
+          MPLBACKEND: Agg
         run: uv run poe coverage
   unit-and-doc-test:
     runs-on: ${{matrix.os}}
@@ -93,6 +95,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --python ${{ matrix.python_version }}
       - name: Run Unit Tests and Doctests Python ${{matrix.python_version}} ${{matrix.os}}
+        env:
+          MPLBACKEND: Agg
         run: uv run poe tests
       - name: Run mypy type check Python ${{matrix.python_version}} ${{matrix.os}}
         run: uv run poe type_check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,11 +40,15 @@ jobs:
         uses: astral-sh/setup-uv@v2
       - name: Install dependencies
         run: uv sync --python ${{ env.PYTHON_VERSION }}
-      - name: Export Publication Version
-        id: export-version
-        run: echo "version=$(uvx hatch version)" >> "$GITHUB_OUTPUT"
       - name: Build Artifacts
-        run: uv build
+        run: |
+          RAW_VERSION=$(uvx hatch version)
+          # Strip any local version metadata (everything after '+') to satisfy PyPI rules
+          CLEAN_VERSION=${RAW_VERSION%%+*}
+          echo "Raw version: $RAW_VERSION"
+          echo "Clean version (for PyPI): $CLEAN_VERSION"
+          # Force hatch to use the sanitized version for the build
+          SETUPTOOLS_SCM_PRETEND_VERSION=$CLEAN_VERSION uv build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/graspologic-org/graspologic/blob/dev/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Have you built the documentation (reference and/or tutorial) and verified the generated documentation is appropriate?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

Fix whl version error:
- https://github.com/graspologic-org/graspologic/actions/runs/19643759002/job/56254810921

Ensured both test-coverage and unit-and-doc-test jobs export MPLBACKEND=Agg before invoking `uv run …`, so Matplotlib stays headless and the Windows runners no longer touch the broken Tk install. This fix `graspologic Reporting` errors:
- https://github.com/graspologic-org/graspologic/actions/runs/19577011727/job/56064948269
- https://github.com/graspologic-org/graspologic/actions/runs/19641687256/job/56246548280
- https://github.com/graspologic-org/graspologic/actions/runs/19641687256/job/56246548265


#### Any other comments?
