### PR TITLE
chore(ci): expand build matrix to include 3.13 and 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get install -y pandoc
-      - uses: actions/checkout@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
         run: uv sync --python ${{ env.PYTHON_VERSION }}
       - name: "Run Reference Documentation Generation"
@@ -39,13 +39,13 @@ jobs:
           uv run pipdeptree >> dependencies_documentation.txt
           uv run poe docsWithTutorials
       - name: Archive documentation version artifact
-        uses: actions/upload-artifact@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dependencies
           path: |
             dependencies_documentation.txt
       - name: Archive documentation artifacts
-        uses: actions/upload-artifact@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: documentation-site
           path: |
@@ -53,13 +53,13 @@ jobs:
   code-format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
         run: uv sync --python ${{ env.PYTHON_VERSION }}
       - name: Run Format Check
@@ -67,13 +67,13 @@ jobs:
   test-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
         run: uv sync --python ${{ env.PYTHON_VERSION }}
       - name: Run Test Coverage
@@ -88,13 +88,13 @@ jobs:
         python_version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Set up Python ${{matrix.python_version}} ${{matrix.os}}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{matrix.python_version}}
       - name: Install uv
-        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
         run: uv sync --python ${{ matrix.python_version }}
       - name: Run Unit Tests and Doctests Python ${{matrix.python_version}} ${{matrix.os}}
@@ -110,7 +110,7 @@ jobs:
           uv run pipdeptree >> $DEPS
         shell: bash
       - name: Archive dependency tree
-        uses: actions/upload-artifact@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dependencies-${{matrix.python_version}}-${{matrix.os}}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 permissions: {}
 
 env:
-  PYTHON_VERSION: '3.14'
+  PYTHON_VERSION: '3.13'
 
 jobs:
   build-reference-documentation:
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 permissions: {}
 
 env:
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: '3.14'
 
 jobs:
   build-reference-documentation:
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,20 @@
 name: graspologic Build
 on:
   push:
+    branches:
+      - 'main'
     paths-ignore:
       - '.all-contributorsrc'
       - 'CONTRIBUTORS.md'
-    branches-ignore:
-      - 'dev'
-      - 'main'
+    tags-ignore:
+      - '**'
   pull_request:
     paths-ignore:
       - '.all-contributorsrc'
       - 'CONTRIBUTORS.md'
   workflow_call:
+
+permissions: {}
 
 env:
   PYTHON_VERSION: '3.10'
@@ -21,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get install -y pandoc
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
       - name: Install dependencies
         run: uv sync --python ${{ env.PYTHON_VERSION }}
       - name: "Run Reference Documentation Generation"
@@ -36,13 +39,13 @@ jobs:
           uv run pipdeptree >> dependencies_documentation.txt
           uv run poe docsWithTutorials
       - name: Archive documentation version artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d # v4
         with:
           name: dependencies
           path: |
             dependencies_documentation.txt
       - name: Archive documentation artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d # v4
         with:
           name: documentation-site
           path: |
@@ -50,13 +53,13 @@ jobs:
   code-format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
       - name: Install dependencies
         run: uv sync --python ${{ env.PYTHON_VERSION }}
       - name: Run Format Check
@@ -64,13 +67,13 @@ jobs:
   test-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
       - name: Install dependencies
         run: uv sync --python ${{ env.PYTHON_VERSION }}
       - name: Run Test Coverage
@@ -85,13 +88,13 @@ jobs:
         python_version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       - name: Set up Python ${{matrix.python_version}} ${{matrix.os}}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{matrix.python_version}}
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
       - name: Install dependencies
         run: uv sync --python ${{ matrix.python_version }}
       - name: Run Unit Tests and Doctests Python ${{matrix.python_version}} ${{matrix.os}}
@@ -107,7 +110,7 @@ jobs:
           uv run pipdeptree >> $DEPS
         shell: bash
       - name: Archive dependency tree
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d # v4
         with:
           name: dependencies-${{matrix.python_version}}-${{matrix.os}}
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,93 +1,86 @@
 name: graspologic Publish
 on:
-  #
-  # When a release tag is created (e.g. v1.0.0), this workflow will be triggered. Hatch's VCS versioning will use the correct version tag.
-  #
-  release:
-    types: [created]
-  #
-  #  On pushes to main and dev, a prerelease version will be cut for the branch. e.g. v1.0.0-pre.10+<hash>
-  #
   push:
-    paths-ignore:
-      - '.all-contributorsrc'
-      - 'CONTRIBUTORS.md'
-    branches:
-      - 'main'
-      - 'dev'
+    tags:
+      - 'v*.*.*'
+
+permissions: {}
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   PYTHON_VERSION: '3.10'
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml
+
   publish:
     runs-on: ubuntu-latest
     needs: build
+    environment: pypi
     permissions:
       id-token: write
-    outputs:
-      version: ${{ steps.export-version.outputs.version }}
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Validate tag format
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' does not match expected format vX.Y.Z"
+            exit 1
+          fi
+      - uses: actions/checkout@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
       - name: Install dependencies
         run: uv sync --python ${{ env.PYTHON_VERSION }}
       - name: Build Artifacts
         run: |
-          RAW_VERSION=$(uvx hatch version)
-          # Strip any local version metadata (everything after '+') to satisfy PyPI rules
-          CLEAN_VERSION=${RAW_VERSION%%+*}
-          echo "Raw version: $RAW_VERSION"
-          echo "Clean version (for PyPI): $CLEAN_VERSION"
-          # Force hatch to use the sanitized version for the build
-          SETUPTOOLS_SCM_PRETEND_VERSION=$CLEAN_VERSION uv build
+          EXPECTED_VERSION="${GITHUB_REF_NAME#v}"
+          ACTUAL_VERSION=$(uvx hatch version)
+          echo "Expected version: $EXPECTED_VERSION"
+          echo "Hatch version: $ACTUAL_VERSION"
+          if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Version mismatch: hatch reports '$ACTUAL_VERSION' but tag implies '$EXPECTED_VERSION'"
+            exit 1
+          fi
+          uv build
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: dist
-          skip-existing: true
           verbose: true
+
   docsite:
     runs-on: ubuntu-latest
     needs: [publish, build]
-    if: github.ref=='refs/heads/main' || github.ref=='refs/heads/dev'
     permissions:
-      id-token: write
       contents: write
     steps:
       - name: Download documentation artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           name: documentation-site
           path: docs/documentation-site
-      - name: Publish reference docs (dev branch)
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.ref=='refs/heads/dev'
+      - name: Publish versioned reference docs
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/documentation-site
-          destination_dir: pre-release
-      - name: Publish reference docs (main branch)
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.ref=='refs/heads/main'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/documentation-site
-          destination_dir: ${{ needs.publish.outputs.version }}
-      - name: Publish latest reference docs (main branch)
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.ref=='refs/heads/main'
+          destination_dir: ${{ github.ref_name }}
+      - name: Publish latest reference docs
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/documentation-site
           destination_dir: latest
 
-        

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: '3.14'
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,16 +31,16 @@ jobs:
             echo "::error::Tag '${GITHUB_REF_NAME}' does not match expected format vX.Y.Z"
             exit 1
           fi
-      - uses: actions/checkout@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@6dfebec6ddbcd197e02256fbdf54deb334fb7f06 # v2
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
         run: uv sync --python ${{ env.PYTHON_VERSION }}
       - name: Build Artifacts
@@ -55,7 +55,7 @@ jobs:
           fi
           uv build
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist
           verbose: true
@@ -67,18 +67,18 @@ jobs:
       contents: write
     steps:
       - name: Download documentation artifact
-        uses: actions/download-artifact@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: documentation-site
           path: docs/documentation-site
       - name: Publish versioned reference docs
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/documentation-site
           destination_dir: ${{ github.ref_name }}
       - name: Publish latest reference docs
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/documentation-site

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  PYTHON_VERSION: '3.14'
+  PYTHON_VERSION: '3.13'
 
 jobs:
   build:


### PR DESCRIPTION
This PR expands the build matrix to include 3.13 and 3.14. It is based off of the previous PR: https://github.com/graspologic-org/graspologic/pull/1104 , which should be merged prior to this one.